### PR TITLE
Document frontend architecture plan

### DIFF
--- a/red
+++ b/red
@@ -1,2 +1,75 @@
 Plano de Arquitetura de Frontend para a Plataforma Prop-Stream
-A filosofia do nosso frontend é ser um "cockpit inteligente" para o investidor. Ele não é apenas um visualizador de dados; é uma interface de controle interativa que traduz a complexidade do backend em ações simples e insights claros para o usuário.
+================================================================
+
+## Visão Geral
+A plataforma Prop-Stream é o centro de comando digital para investidores imobiliários, oferecendo visão
+consolidada de ativos, inteligência preditiva e ferramentas de execução. A camada de frontend deve traduzir
+analíticos complexos em ações simples, garantindo que decisões críticas possam ser tomadas com confiança e
+rapidez.
+
+## Princípios Arquiteturais
+1. **Cockpit Inteligente**: cada tela deve priorizar indicadores, alertas acionáveis e atalhos para tarefas
+   frequentes, reduzindo o tempo entre insight e ação.
+2. **Modularidade Orientada a Domínio**: componentes e serviços são organizados de acordo com fluxos de trabalho
+   (originação, análise, gestão de portfólio), facilitando evolução independente.
+3. **Resiliência e Observabilidade**: tratamento explícito de estados de carregamento, erro e vazio, aliado a
+   telemetria detalhada para monitorar performance e adoção de funcionalidades.
+4. **Performance Percebida**: pré-busca de dados críticos, renderização progressiva e atualização otimista para
+   manter a sensação de fluidez mesmo em redes lentas.
+5. **Segurança by Design**: isolamento de credenciais, aplicação rigorosa de controles de acesso e sanitização de
+   dados provenientes da API.
+
+## Stack Tecnológica
+- **Framework**: React 18 com TypeScript para tipagem forte e melhor previsibilidade.
+- **Camada de UI**: Design System próprio apoiado em Storybook, com tokens de estilo baseados em Tailwind CSS.
+- **Gerenciamento de Estado**: Redux Toolkit para estado global, React Query para cache de dados assíncronos e
+  sincronização com o backend.
+- **Roteamento**: React Router 6 com carregamento preguiçoso e divisão por domínios funcionais.
+- **Comunicação com APIs**: camada de serviços REST usando Axios configurado com interceptadores de autenticação,
+  além de suporte a WebSockets para streaming de eventos do marketplace.
+- **Testes**: Vitest e React Testing Library para testes unitários/componentes; Cypress para testes end-to-end.
+- **Build e Deploy**: Vite para build rápido, integração contínua com GitHub Actions e entrega via CDN com
+  versionamento automatizado.
+
+## Estrutura Modular
+- **App Shell**: layout persistente com cabeçalho de navegação, seletor de portfólio e painel lateral de alertas.
+- **Domínios Funcionais**:
+  - *Originação de Negócios*: pipeline de oportunidades, scoring de imóveis, integração com origens externas.
+  - *Análise e Valuation*: dashboards comparativos, simulações financeiras, relatórios exportáveis.
+  - *Gestão de Portfólio*: visão consolidada de carteira, monitoramento de métricas-chave e alertas de risco.
+- **Biblioteca de Componentes**: botões, inputs, tabelas responsivas e gráficos padronizados com suporte a tema
+  escuro/claro.
+- **Serviços Compartilhados**: módulo de autenticação, tratadores de erros, gateway de notificações e utilitários
+  de formatação (moeda, datas, indicadores).
+- **Camada de Visualização de Dados**: wrappers reutilizáveis para gráficos (ECharts) e mapas interativos (Mapbox)
+  alinhados às necessidades do domínio imobiliário.
+
+## Fluxo de Dados e Integração
+1. **Autenticação e Contexto do Usuário**: após login, tokens são armazenados com segurança e o perfil do usuário é
+   carregado para configurar permissões e preferências.
+2. **Camada de Serviços**: chamadas HTTP são centralizadas, com tratamento uniforme de erros, retentativas
+   configuráveis e logs para observabilidade.
+3. **Sincronização de Estado**: React Query gerencia cache e invalidação por domínio; ações críticas utilizam
+   padrões Command/Query e atualizações otimistas.
+4. **Streaming de Eventos**: notificações e atualizações em tempo real (leilões, alterações de status) chegam via
+   WebSockets, atualizando o estado global e disparando toasts/contextualizações.
+5. **Pipeline de Dados Analíticos**: dados pesados são pré-processados no backend; o frontend consome endpoints
+   agregados e aplica filtros locais, preservando performance.
+
+## Experiência do Usuário e Design
+- **Narrativa de Cockpit**: páginas estruturadas em painéis com prioridade visual para indicadores-chave (KPIs) e
+  trilhas de ação claramente identificáveis.
+- **Personalização**: preferências do usuário (widgets fixos, filtros salvos) armazenadas e sincronizadas entre
+  dispositivos para continuidade da experiência.
+- **Responsividade**: layout adaptável a desktops, tablets e telas grandes de sala de investimentos, com componentes
+  fluidos e densidade informacional ajustável.
+- **Acessibilidade**: conformidade com WCAG 2.1 AA, incluindo suporte a leitores de tela, navegação por teclado e
+  contraste adequado.
+- **Feedback Contínuo**: estados visuais consistentes (carregando, sucesso, erro), toasts não intrusivos e logs de
+  auditoria acessíveis para ações críticas.
+
+## Governança e Evolução
+- **Documentação Viva**: Storybook e MDX centralizando padrões de uso dos componentes e orientações de UX.
+- **Qualidade Contínua**: pipelines CI executando lint, testes e auditoria de performance (Lighthouse) a cada merge.
+- **Roadmap Modular**: priorização de evoluções por domínios, permitindo squads independentes com contratos de API
+  bem definidos.


### PR DESCRIPTION
## Summary
- replace placeholder architecture note with a full multi-section frontend plan for Prop-Stream
- document guiding principles, technology stack, modular structure, data flow, and UX directives
- add governance guidance to support ongoing quality and evolution

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cdd260547483268c831753a65f9f24