### PR TITLE
feat: bootstrap prop-stream app shell

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Prop-Stream</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "prop-stream",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "vitest",
+    "test:watch": "vitest --watch"
+  },
+  "dependencies": {
+    "@reduxjs/toolkit": "^1.9.7",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-redux": "^8.1.2",
+    "react-router-dom": "^6.15.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.1.5",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.1.0",
+    "jsdom": "^22.1.0",
+    "typescript": "^5.2.2",
+    "vite": "^4.4.9",
+    "vitest": "^0.34.6"
+  }
+}

--- a/src/app/AppShell.css
+++ b/src/app/AppShell.css
@@ -1,0 +1,208 @@
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.95) 0%, rgba(30, 41, 59, 0.95) 100%);
+  color: #f1f5f9;
+}
+
+.app-shell--light {
+  background: linear-gradient(180deg, rgba(248, 250, 252, 0.95) 0%, rgba(226, 232, 240, 0.95) 100%);
+  color: #0f172a;
+}
+
+.app-shell__header {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  padding: 1rem 2rem;
+  gap: 1rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.3);
+  backdrop-filter: blur(12px);
+}
+
+.app-shell__brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.app-shell__logo {
+  font-size: 1.75rem;
+}
+
+.app-shell__subtitle {
+  margin: 0;
+  font-size: 0.875rem;
+  color: inherit;
+  opacity: 0.72;
+}
+
+.app-shell__nav {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.app-shell__nav a {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 600;
+  color: inherit;
+  opacity: 0.7;
+  transition: opacity 0.2s ease, background-color 0.2s ease;
+}
+
+.app-shell__nav a.active {
+  opacity: 1;
+  background-color: rgba(148, 163, 184, 0.2);
+}
+
+.app-shell__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.app-shell__portfolio {
+  display: grid;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+}
+
+.app-shell__portfolio select {
+  padding: 0.35rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background-color: rgba(15, 23, 42, 0.4);
+  color: inherit;
+}
+
+.app-shell--light .app-shell__portfolio select {
+  background-color: rgba(255, 255, 255, 0.8);
+}
+
+.app-shell__button {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background-color: rgba(59, 130, 246, 0.2);
+  color: inherit;
+  cursor: pointer;
+}
+
+.app-shell__button:hover {
+  border-color: rgba(59, 130, 246, 0.6);
+}
+
+.app-shell__layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 20rem;
+  flex: 1;
+  min-height: 0;
+}
+
+.app-shell__main {
+  padding: 2rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.app-shell__context {
+  padding: 1rem 1.5rem;
+  border-radius: 1rem;
+  background-color: rgba(15, 23, 42, 0.45);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+}
+
+.app-shell--light .app-shell__context {
+  background-color: rgba(255, 255, 255, 0.7);
+}
+
+.app-shell__alerts {
+  position: relative;
+  border-left: 1px solid rgba(148, 163, 184, 0.2);
+  background-color: rgba(15, 23, 42, 0.6);
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-shell__alerts--open {
+  transform: translateX(0%);
+}
+
+.app-shell--light .app-shell__alerts {
+  background-color: rgba(255, 255, 255, 0.8);
+}
+
+.app-shell__alerts-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.app-shell__alerts-list {
+  list-style: none;
+  margin: 0;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  overflow-y: auto;
+}
+
+.app-shell__alert {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  display: grid;
+  gap: 0.5rem;
+  background-color: rgba(30, 41, 59, 0.75);
+}
+
+.app-shell--light .app-shell__alert {
+  background-color: rgba(226, 232, 240, 0.8);
+}
+
+.app-shell__alert--critical {
+  box-shadow: inset 0 0 0 1px rgba(239, 68, 68, 0.6);
+}
+
+.app-shell__alert--warning {
+  box-shadow: inset 0 0 0 1px rgba(250, 204, 21, 0.6);
+}
+
+.app-shell__alert--info {
+  box-shadow: inset 0 0 0 1px rgba(14, 165, 233, 0.6);
+}
+
+.app-shell__alert-message {
+  margin: 0;
+  font-weight: 600;
+}
+
+.app-shell__alerts-empty {
+  opacity: 0.7;
+  font-style: italic;
+}
+
+@media (max-width: 1024px) {
+  .app-shell__layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .app-shell__alerts {
+    position: fixed;
+    inset: 0 0 auto auto;
+    width: min(20rem, 80vw);
+    height: 100%;
+    z-index: 10;
+    box-shadow: -12px 0 24px rgba(15, 23, 42, 0.5);
+  }
+}

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useMemo } from 'react';
+import { NavLink, Outlet } from 'react-router-dom';
+import { useAppDispatch, useAppSelector } from './hooks';
+import { selectPortfolio, setPortfolios, type Portfolio } from '../store/portfolioSlice';
+import { toggleTheme } from '../store/preferencesSlice';
+import { dismissAlert, togglePanel } from '../store/alertsSlice';
+import './AppShell.css';
+import { EmptyState } from '../components/FeedbackState';
+
+interface AppShellProps {
+  portfolios: Portfolio[];
+}
+
+export function AppShell({ portfolios }: AppShellProps) {
+  const dispatch = useAppDispatch();
+  const { selectedPortfolioId, portfolios: statePortfolios } = useAppSelector((state) => state.portfolio);
+  const { theme } = useAppSelector((state) => state.preferences);
+  const { isOpen, items } = useAppSelector((state) => state.alerts);
+
+  useEffect(() => {
+    dispatch(setPortfolios(portfolios));
+  }, [dispatch, portfolios]);
+
+  useEffect(() => {
+    if (portfolios.length > 0 && !selectedPortfolioId) {
+      dispatch(selectPortfolio(portfolios[0].id));
+    }
+  }, [dispatch, portfolios, selectedPortfolioId]);
+
+  const resolvedPortfolios = statePortfolios.length > 0 ? statePortfolios : portfolios;
+  const selectValue = selectedPortfolioId ?? resolvedPortfolios[0]?.id ?? '';
+
+  const activePortfolio = useMemo(
+    () => resolvedPortfolios.find((portfolio) => portfolio.id === selectValue) ?? null,
+    [resolvedPortfolios, selectValue]
+  );
+
+  return (
+    <div className={`app-shell app-shell--${theme}`} data-testid="app-shell">
+      <header className="app-shell__header" role="banner">
+        <div className="app-shell__brand">
+          <span className="app-shell__logo" aria-hidden>
+            ⛰
+          </span>
+          <div>
+            <h1>Prop-Stream</h1>
+            <p className="app-shell__subtitle">Inteligência para investimentos imobiliários</p>
+          </div>
+        </div>
+        <nav aria-label="Domínios do produto" className="app-shell__nav">
+          <NavLink to="/origination">Originação</NavLink>
+          <NavLink to="/analysis">Análise</NavLink>
+          <NavLink to="/portfolio">Portfólio</NavLink>
+        </nav>
+        <div className="app-shell__actions">
+          <label className="app-shell__portfolio">
+            <span>Portfólio</span>
+            <select
+              disabled={resolvedPortfolios.length === 0}
+              value={selectValue}
+              onChange={(event) => dispatch(selectPortfolio(event.target.value))}
+              aria-label="Selecionar portfólio"
+            >
+              {resolvedPortfolios.map((portfolio) => (
+                <option key={portfolio.id} value={portfolio.id}>
+                  {portfolio.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button type="button" onClick={() => dispatch(toggleTheme())} className="app-shell__button">
+            Alternar tema
+          </button>
+          <button
+            type="button"
+            onClick={() => dispatch(togglePanel())}
+            className="app-shell__button"
+            aria-expanded={isOpen}
+            aria-controls="alert-panel"
+          >
+            Alertas ({items.length})
+          </button>
+        </div>
+      </header>
+      <div className="app-shell__layout">
+        <main className="app-shell__main" role="main">
+          {resolvedPortfolios.length === 0 ? (
+            <EmptyState message="Cadastre um portfólio para desbloquear os painéis de performance." />
+          ) : (
+            <>
+              {activePortfolio ? (
+                <header className="app-shell__context">
+                  <h2>{activePortfolio.name}</h2>
+                  <p>
+                    Segmento: {activePortfolio.segment} · Patrimônio sob gestão:{' '}
+                    {new Intl.NumberFormat('pt-BR', {
+                      style: 'currency',
+                      currency: 'BRL'
+                    }).format(activePortfolio.aum)}
+                  </p>
+                </header>
+              ) : null}
+              <Outlet />
+            </>
+          )}
+        </main>
+        <aside
+          id="alert-panel"
+          className={`app-shell__alerts ${isOpen ? 'app-shell__alerts--open' : ''}`}
+          aria-live="polite"
+          aria-hidden={!isOpen}
+        >
+          <header className="app-shell__alerts-header">
+            <h2>Alertas</h2>
+            <button type="button" onClick={() => dispatch(togglePanel())} className="app-shell__button">
+              Fechar
+            </button>
+          </header>
+          <ul className="app-shell__alerts-list">
+            {items.length === 0 ? (
+              <li className="app-shell__alerts-empty">Nenhum alerta ativo.</li>
+            ) : (
+              items.map((alert) => (
+                <li key={alert.id} className={`app-shell__alert app-shell__alert--${alert.severity}`}>
+                  <div>
+                    <p className="app-shell__alert-message">{alert.message}</p>
+                    <time dateTime={alert.timestamp}>
+                      {new Date(alert.timestamp).toLocaleString('pt-BR', {
+                        hour: '2-digit',
+                        minute: '2-digit',
+                        day: '2-digit',
+                        month: 'short'
+                      })}
+                    </time>
+                  </div>
+                  <button type="button" onClick={() => dispatch(dismissAlert(alert.id))} className="app-shell__button">
+                    Arquivar
+                  </button>
+                </li>
+              ))
+            )}
+          </ul>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/src/app/__tests__/app-shell.integration.test.tsx
+++ b/src/app/__tests__/app-shell.integration.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { createStore } from '../../store';
+import { routes } from '../router';
+
+async function renderWithRouter(initialEntries: string[] = ['/']) {
+  const store = createStore();
+  const router = createMemoryRouter(routes, { initialEntries });
+  render(
+    <Provider store={store}>
+      <RouterProvider router={router} />
+    </Provider>
+  );
+
+  await screen.findByTestId('app-shell');
+}
+
+describe('AppShell integration', () => {
+  it('renderiza cabeçalho, seletor de portfólio e painel de alertas', async () => {
+    await renderWithRouter();
+
+    const header = screen.getByRole('banner');
+    expect(header).toBeInTheDocument();
+
+    const portfolioSelect = within(header).getByLabelText(/selecionar portfólio/i);
+    expect(portfolioSelect).toBeEnabled();
+
+    await waitFor(() => expect(screen.getByRole('heading', { name: /pipeline de originação/i })).toBeVisible());
+  });
+
+  it('permite navegação entre domínios', async () => {
+    const user = userEvent.setup();
+    await renderWithRouter(['/analysis']);
+
+    await waitFor(() => expect(screen.getByRole('heading', { name: /análise e valuation/i })).toBeVisible());
+
+    await user.click(screen.getByRole('link', { name: /portfólio/i }));
+    await waitFor(() => expect(screen.getByRole('heading', { name: /gestão de portfólio/i })).toBeVisible());
+  });
+});

--- a/src/app/hooks.ts
+++ b/src/app/hooks.ts
@@ -1,0 +1,5 @@
+import { useDispatch, useSelector, type TypedUseSelectorHook } from 'react-redux';
+import type { AppDispatch, RootState } from '../store';
+
+export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,0 +1,103 @@
+import { Suspense, lazy } from 'react';
+import {
+  Await,
+  Navigate,
+  createBrowserRouter,
+  type RouteObject,
+  useAsyncError,
+  useLoaderData,
+  useRouteError
+} from 'react-router-dom';
+import { AppShell } from './AppShell';
+import { ErrorState, LoadingState } from '../components/FeedbackState';
+import { fetchPortfolios } from '../services/portfolios';
+import type { Portfolio } from '../store/portfolioSlice';
+
+const OriginationDashboard = lazy(() => import('../domains/origination/OriginationDashboard'));
+const AnalysisDashboard = lazy(() => import('../domains/analysis/AnalysisDashboard'));
+const PortfolioOverview = lazy(() => import('../domains/portfolio/PortfolioOverview'));
+const NotFoundPage = lazy(() => import('../domains/not-found/NotFoundPage'));
+
+interface RootLoaderData {
+  portfolios: Promise<Portfolio[]>;
+}
+
+export async function rootLoader(): Promise<{ portfolios: Promise<Portfolio[]> }> {
+  return {
+    portfolios: fetchPortfolios()
+  };
+}
+
+function RootLayout() {
+  const data = useLoaderData() as RootLoaderData;
+
+  return (
+    <Suspense fallback={<LoadingState message="Montando cockpit principal..." />}>
+      <Await resolve={data.portfolios} errorElement={<RootAwaitError />}>
+        {(portfolios) => <AppShell portfolios={portfolios} />}
+      </Await>
+    </Suspense>
+  );
+}
+
+function RootAwaitError() {
+  const error = useAsyncError() as Error | undefined;
+  return <ErrorState message={error?.message ?? 'Não foi possível carregar os portfólios.'} />;
+}
+
+function RootErrorBoundary() {
+  const error = useRouteError() as Error | undefined;
+  return <ErrorState message={error?.message ?? 'Falha ao carregar a aplicação.'} />;
+}
+
+const routeChildren: RouteObject[] = [
+  {
+    index: true,
+    element: <Navigate to="/origination" replace />
+  },
+  {
+    path: 'origination',
+    element: (
+      <Suspense fallback={<LoadingState message="Carregando originação..." />}>
+        <OriginationDashboard />
+      </Suspense>
+    )
+  },
+  {
+    path: 'analysis',
+    element: (
+      <Suspense fallback={<LoadingState message="Carregando análise..." />}>
+        <AnalysisDashboard />
+      </Suspense>
+    )
+  },
+  {
+    path: 'portfolio',
+    element: (
+      <Suspense fallback={<LoadingState message="Carregando visão de portfólio..." />}>
+        <PortfolioOverview />
+      </Suspense>
+    )
+  },
+  {
+    path: '*',
+    element: (
+      <Suspense fallback={<LoadingState message="Buscando rota..." />}>
+        <NotFoundPage />
+      </Suspense>
+    )
+  }
+];
+
+export const routes: RouteObject[] = [
+  {
+    id: 'root',
+    path: '/',
+    loader: rootLoader,
+    element: <RootLayout />, 
+    errorElement: <RootErrorBoundary />, 
+    children: routeChildren
+  }
+];
+
+export const router = createBrowserRouter(routes);

--- a/src/components/FeedbackState.tsx
+++ b/src/components/FeedbackState.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from 'react';
+
+interface FeedbackStateProps {
+  title: string;
+  description?: string;
+  icon?: ReactNode;
+  action?: ReactNode;
+}
+
+const baseStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '0.5rem',
+  padding: '2rem',
+  textAlign: 'center'
+};
+
+export function FeedbackState({ title, description, icon, action }: FeedbackStateProps) {
+  return (
+    <section style={baseStyle} aria-live="polite">
+      {icon}
+      <h2 style={{ margin: 0 }}>{title}</h2>
+      {description ? <p style={{ margin: 0, maxWidth: '32rem' }}>{description}</p> : null}
+      {action}
+    </section>
+  );
+}
+
+export function LoadingState({ message = 'Carregando...' }: { message?: string }) {
+  return <FeedbackState title={message} description="Estamos preparando os dados mais recentes." />;
+}
+
+export function ErrorState({ message }: { message: string }) {
+  return (
+    <FeedbackState
+      title="Algo inesperado aconteceu"
+      description={message}
+      action={<small role="alert">Tente novamente ou contate o suporte.</small>}
+    />
+  );
+}
+
+export function EmptyState({ message, action }: { message: string; action?: ReactNode }) {
+  return (
+    <FeedbackState
+      title="Nada por aqui ainda"
+      description={message}
+      action={action ?? <small>Cadastre um portfólio para começar a monitorar seus ativos.</small>}
+    />
+  );
+}

--- a/src/domains/analysis/AnalysisDashboard.tsx
+++ b/src/domains/analysis/AnalysisDashboard.tsx
@@ -1,0 +1,10 @@
+export default function AnalysisDashboard() {
+  return (
+    <section aria-labelledby="analysis-heading">
+      <h2 id="analysis-heading">Análise e valuation</h2>
+      <p>
+        Compare cenários financeiros, teste hipóteses de mercado e gere relatórios para aprovação de investimentos.
+      </p>
+    </section>
+  );
+}

--- a/src/domains/not-found/NotFoundPage.tsx
+++ b/src/domains/not-found/NotFoundPage.tsx
@@ -1,0 +1,11 @@
+import { Link } from 'react-router-dom';
+
+export default function NotFoundPage() {
+  return (
+    <section aria-labelledby="not-found-heading">
+      <h2 id="not-found-heading">Conteúdo não encontrado</h2>
+      <p>Revisamos nossas rotas, mas não encontramos o recurso solicitado.</p>
+      <Link to="/">Voltar para o cockpit</Link>
+    </section>
+  );
+}

--- a/src/domains/origination/OriginationDashboard.tsx
+++ b/src/domains/origination/OriginationDashboard.tsx
@@ -1,0 +1,10 @@
+export default function OriginationDashboard() {
+  return (
+    <section aria-labelledby="origination-heading">
+      <h2 id="origination-heading">Pipeline de originação</h2>
+      <p>
+        Acompanhe a evolução das oportunidades de aquisição, priorize diligências e antecipe riscos regulatórios.
+      </p>
+    </section>
+  );
+}

--- a/src/domains/portfolio/PortfolioOverview.tsx
+++ b/src/domains/portfolio/PortfolioOverview.tsx
@@ -1,0 +1,10 @@
+export default function PortfolioOverview() {
+  return (
+    <section aria-labelledby="portfolio-heading">
+      <h2 id="portfolio-heading">Gestão de portfólio</h2>
+      <p>
+        Monitore KPIs de ocupação, rentabilidade e liquidez em tempo real para manter a governança da carteira.
+      </p>
+    </section>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,26 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  background-color: #0f172a;
+  color: #e2e8f0;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+a {
+  color: inherit;
+}
+
+button,
+select {
+  font: inherit;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { Provider } from 'react-redux';
+import { RouterProvider } from 'react-router-dom';
+import { store } from './store';
+import { router } from './app/router';
+import './index.css';
+import { LoadingState } from './components/FeedbackState';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <Provider store={store}>
+      <RouterProvider router={router} fallbackElement={<LoadingState message="Preparando cockpit..." />} />
+    </Provider>
+  </React.StrictMode>
+);

--- a/src/services/portfolios.ts
+++ b/src/services/portfolios.ts
@@ -1,0 +1,27 @@
+import type { Portfolio } from '../store/portfolioSlice';
+
+const SAMPLE_PORTFOLIOS: Portfolio[] = [
+  {
+    id: 'res-001',
+    name: 'Residencial Alfa',
+    segment: 'Residencial',
+    aum: 450_000_000
+  },
+  {
+    id: 'com-002',
+    name: 'Towers Comerciais',
+    segment: 'Comercial',
+    aum: 730_000_000
+  },
+  {
+    id: 'mix-003',
+    name: 'Smart Mix Urbano',
+    segment: 'Misto',
+    aum: 615_000_000
+  }
+];
+
+export async function fetchPortfolios(): Promise<Portfolio[]> {
+  await new Promise((resolve) => setTimeout(resolve, 120));
+  return SAMPLE_PORTFOLIOS;
+}

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/src/store/alertsSlice.ts
+++ b/src/store/alertsSlice.ts
@@ -1,0 +1,67 @@
+import { createSlice, nanoid, type PayloadAction } from '@reduxjs/toolkit';
+
+export type AlertSeverity = 'info' | 'warning' | 'critical';
+
+export interface AlertItem {
+  id: string;
+  severity: AlertSeverity;
+  message: string;
+  timestamp: string;
+}
+
+interface AlertsState {
+  isOpen: boolean;
+  items: AlertItem[];
+}
+
+const initialState: AlertsState = {
+  isOpen: false,
+  items: [
+    {
+      id: nanoid(),
+      severity: 'warning',
+      message: 'Vacância do portfólio comercial acima do limite projetado.',
+      timestamp: new Date().toISOString()
+    },
+    {
+      id: nanoid(),
+      severity: 'critical',
+      message: 'Oferta vencedora pendente de assinatura expira em 2 horas.',
+      timestamp: new Date().toISOString()
+    }
+  ]
+};
+
+const alertsSlice = createSlice({
+  name: 'alerts',
+  initialState,
+  reducers: {
+    togglePanel(state) {
+      state.isOpen = !state.isOpen;
+    },
+    closePanel(state) {
+      state.isOpen = false;
+    },
+    addAlert: {
+      reducer(state, action: PayloadAction<AlertItem>) {
+        state.items.unshift(action.payload);
+      },
+      prepare(message: string, severity: AlertSeverity = 'info') {
+        return {
+          payload: {
+            id: nanoid(),
+            message,
+            severity,
+            timestamp: new Date().toISOString()
+          }
+        };
+      }
+    },
+    dismissAlert(state, action: PayloadAction<string>) {
+      state.items = state.items.filter((item) => item.id !== action.payload);
+    }
+  }
+});
+
+export const { togglePanel, closePanel, addAlert, dismissAlert } = alertsSlice.actions;
+export default alertsSlice.reducer;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,24 @@
+import { configureStore, type PreloadedState } from '@reduxjs/toolkit';
+import alertsReducer from './alertsSlice';
+import portfolioReducer from './portfolioSlice';
+import preferencesReducer from './preferencesSlice';
+
+const reducer = {
+  alerts: alertsReducer,
+  portfolio: portfolioReducer,
+  preferences: preferencesReducer
+};
+
+export const store = configureStore({
+  reducer
+});
+
+export type AppStore = typeof store;
+export type RootState = ReturnType<AppStore['getState']>;
+export type AppDispatch = AppStore['dispatch'];
+
+export const createStore = (preloadedState?: PreloadedState<RootState>) =>
+  configureStore({
+    reducer,
+    preloadedState
+  });

--- a/src/store/portfolioSlice.ts
+++ b/src/store/portfolioSlice.ts
@@ -1,0 +1,42 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+export interface Portfolio {
+  id: string;
+  name: string;
+  segment: 'Residencial' | 'Comercial' | 'Industrial' | 'Misto';
+  aum: number;
+}
+
+interface PortfolioState {
+  portfolios: Portfolio[];
+  selectedPortfolioId: string | null;
+}
+
+const initialState: PortfolioState = {
+  portfolios: [],
+  selectedPortfolioId: null
+};
+
+const portfolioSlice = createSlice({
+  name: 'portfolio',
+  initialState,
+  reducers: {
+    setPortfolios(state, action: PayloadAction<Portfolio[]>) {
+      state.portfolios = action.payload;
+      if (state.portfolios.length === 0) {
+        state.selectedPortfolioId = null;
+        return;
+      }
+
+      if (!state.selectedPortfolioId || !state.portfolios.some(({ id }) => id === state.selectedPortfolioId)) {
+        state.selectedPortfolioId = state.portfolios[0].id;
+      }
+    },
+    selectPortfolio(state, action: PayloadAction<string>) {
+      state.selectedPortfolioId = action.payload;
+    }
+  }
+});
+
+export const { setPortfolios, selectPortfolio } = portfolioSlice.actions;
+export default portfolioSlice.reducer;

--- a/src/store/preferencesSlice.ts
+++ b/src/store/preferencesSlice.ts
@@ -1,0 +1,30 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+type Theme = 'light' | 'dark';
+type Density = 'confortavel' | 'compacto';
+
+interface PreferencesState {
+  theme: Theme;
+  density: Density;
+}
+
+const initialState: PreferencesState = {
+  theme: 'dark',
+  density: 'confortavel'
+};
+
+const preferencesSlice = createSlice({
+  name: 'preferences',
+  initialState,
+  reducers: {
+    toggleTheme(state) {
+      state.theme = state.theme === 'dark' ? 'light' : 'dark';
+    },
+    setDensity(state, action: { payload: Density }) {
+      state.density = action.payload;
+    }
+  }
+});
+
+export const { toggleTheme, setDensity } = preferencesSlice.actions;
+export default preferencesSlice.reducer;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vitest/importMeta", "vitest/globals"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.ts',
+    css: true
+  }
+});


### PR DESCRIPTION
## Summary
- implement an AppShell layout with persistent navigation, portfolio selector and alert side panel
- wire React Router with lazy loaded domain routes and shared loading/error fallbacks
- add Redux Toolkit store for portfolio, preference and alert states plus integration test scaffolding

## Testing
- npm test *(fails: vitest not found because npm install is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cdd5e801a08326b4c7944c7f6fb83e