### PR TITLE
feat: bootstrap domain modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Prop-Stream</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "prop-stream",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@reduxjs/toolkit": "^1.9.7",
+    "@tanstack/react-query": "^4.36.1",
+    "axios": "^1.6.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-redux": "^8.1.3",
+    "react-router-dom": "^6.15.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.1.3",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.0.4",
+    "jsdom": "^22.1.0",
+    "typescript": "^5.2.2",
+    "vite": "^4.4.11",
+    "vitest": "^0.34.6"
+  }
+}

--- a/src/app/hooks.ts
+++ b/src/app/hooks.ts
@@ -1,0 +1,5 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import type { AppDispatch, RootState } from './store';
+
+export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/app/layout.css
+++ b/src/app/layout.css
@@ -1,0 +1,33 @@
+.app-shell {
+  font-family: system-ui, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-shell__header {
+  background: #0f172a;
+  color: #f8fafc;
+  padding: 1rem 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.app-shell__header nav a {
+  color: #cbd5f5;
+  margin-inline: 0.75rem;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.app-shell__header nav a.active {
+  color: #38bdf8;
+}
+
+.app-shell__main {
+  flex: 1;
+  padding: 2rem;
+  background: #f1f5f9;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,21 @@
+import { PropsWithChildren } from 'react';
+import { NavLink, Outlet } from 'react-router-dom';
+import './layout.css';
+
+export function AppLayout({ children }: PropsWithChildren) {
+  return (
+    <div className="app-shell">
+      <header className="app-shell__header">
+        <h1>Prop-Stream Cockpit</h1>
+        <nav>
+          <NavLink to="/origination">Originação</NavLink>
+          <NavLink to="/analysis">Análise</NavLink>
+          <NavLink to="/portfolio">Portfólio</NavLink>
+        </nav>
+      </header>
+      <main className="app-shell__main">{children ?? <Outlet />}</main>
+    </div>
+  );
+}
+
+export default AppLayout;

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,0 +1,46 @@
+import { Suspense, lazy, LazyExoticComponent, ComponentType } from 'react';
+import { Navigate, createBrowserRouter } from 'react-router-dom';
+import AppLayout from './layout';
+import { loader as originationLoader } from '../features/origination/pages/loader';
+import { loader as analysisLoader } from '../features/analysis/pages/loader';
+import { loader as portfolioLoader } from '../features/portfolio/pages/loader';
+
+function withSuspense<T extends ComponentType>(Component: LazyExoticComponent<T>) {
+  return (
+    <Suspense fallback={<div>Carregando módulo...</div>}>
+      <Component />
+    </Suspense>
+  );
+}
+
+const OriginationPage = lazy(() => import('../features/origination/pages'));
+const AnalysisPage = lazy(() => import('../features/analysis/pages'));
+const PortfolioPage = lazy(() => import('../features/portfolio/pages'));
+
+export const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <AppLayout />, // AppLayout already renders Outlet
+    children: [
+      {
+        index: true,
+        element: <Navigate to="/origination" replace />
+      },
+      {
+        path: 'origination',
+        element: withSuspense(OriginationPage),
+        loader: originationLoader
+      },
+      {
+        path: 'analysis',
+        element: withSuspense(AnalysisPage),
+        loader: analysisLoader
+      },
+      {
+        path: 'portfolio',
+        element: withSuspense(PortfolioPage),
+        loader: portfolioLoader
+      }
+    ]
+  }
+]);

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,0 +1,15 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { originationReducer } from '../features/origination/slice';
+import { analysisReducer } from '../features/analysis/slice';
+import { portfolioReducer } from '../features/portfolio/slice';
+
+export const store = configureStore({
+  reducer: {
+    origination: originationReducer,
+    analysis: analysisReducer,
+    portfolio: portfolioReducer
+  }
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/src/features/analysis/__tests__/slice.test.ts
+++ b/src/features/analysis/__tests__/slice.test.ts
@@ -1,0 +1,40 @@
+import { analysisReducer, dashboardLoaded, executeSimulation } from '../slice';
+import { ComparativeMetric } from '../api';
+
+describe('analysis reducer', () => {
+  it('carrega métricas do dashboard', () => {
+    const metrics: ComparativeMetric[] = [
+      { metric: 'Cap Rate', subject: 0.1, benchmark: 0.08 }
+    ];
+
+    const state = analysisReducer(undefined, dashboardLoaded(metrics));
+
+    expect(state.metrics).toEqual(metrics);
+  });
+
+  it('mantém atualização otimista durante simulação', () => {
+    const baseState = analysisReducer(
+      undefined,
+      dashboardLoaded([{ metric: 'Cap Rate', subject: 0.1, benchmark: 0.08 }])
+    );
+
+    const pending = analysisReducer(
+      baseState,
+      executeSimulation.pending('sim-1', { scenario: 'custom', capital: 1_500_000 })
+    );
+
+    expect(pending.metrics[0].subject).not.toBe(0.1);
+
+    const fulfilled = analysisReducer(
+      pending,
+      executeSimulation.fulfilled(
+        { metrics: [{ metric: 'Cap Rate', subject: 0.2, benchmark: 0.08 }] },
+        'sim-1',
+        { scenario: 'custom', capital: 1_500_000 }
+      )
+    );
+
+    expect(fulfilled.metrics[0].subject).toBe(0.2);
+    expect(fulfilled.optimisticSnapshot).toBeUndefined();
+  });
+});

--- a/src/features/analysis/api/index.ts
+++ b/src/features/analysis/api/index.ts
@@ -1,0 +1,28 @@
+export interface ComparativeMetric {
+  metric: string;
+  subject: number;
+  benchmark: number;
+}
+
+export interface SimulationPayload {
+  scenario: string;
+  capital: number;
+}
+
+const mockMetrics: ComparativeMetric[] = [
+  { metric: 'Cap Rate', subject: 0.082, benchmark: 0.075 },
+  { metric: 'Vacância', subject: 0.05, benchmark: 0.08 }
+];
+
+export async function fetchComparativeDashboard(): Promise<ComparativeMetric[]> {
+  await new Promise((resolve) => setTimeout(resolve, 40));
+  return mockMetrics;
+}
+
+export async function runScenario(payload: SimulationPayload): Promise<ComparativeMetric[]> {
+  await new Promise((resolve) => setTimeout(resolve, 40));
+  return mockMetrics.map((metric) => ({
+    ...metric,
+    subject: metric.subject * (payload.capital / 1_000_000)
+  }));
+}

--- a/src/features/analysis/components/ComparativeTable.tsx
+++ b/src/features/analysis/components/ComparativeTable.tsx
@@ -1,0 +1,34 @@
+import { ComparativeMetric } from '../api';
+
+interface ComparativeTableProps {
+  metrics: ComparativeMetric[];
+}
+
+export function ComparativeTable({ metrics }: ComparativeTableProps) {
+  if (!metrics.length) {
+    return <p>Nenhum dado comparativo disponível.</p>;
+  }
+
+  return (
+    <table className="comparative-table">
+      <thead>
+        <tr>
+          <th>Métrica</th>
+          <th>Carteira</th>
+          <th>Benchmark</th>
+        </tr>
+      </thead>
+      <tbody>
+        {metrics.map((metric) => (
+          <tr key={metric.metric}>
+            <td>{metric.metric}</td>
+            <td>{(metric.subject * 100).toFixed(1)}%</td>
+            <td>{(metric.benchmark * 100).toFixed(1)}%</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export default ComparativeTable;

--- a/src/features/analysis/hooks/__tests__/useComparativeDashboard.test.tsx
+++ b/src/features/analysis/hooks/__tests__/useComparativeDashboard.test.tsx
@@ -1,0 +1,43 @@
+import { PropsWithChildren } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import * as api from '../../api';
+import { useComparativeDashboard } from '../useComparativeDashboard';
+import { analysisReducer } from '../../slice';
+import { originationReducer } from '../../../origination/slice';
+import { portfolioReducer } from '../../../portfolio/slice';
+
+vi.mock('../../api');
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, cacheTime: 0 } } });
+  const store = configureStore({
+    reducer: {
+      analysis: analysisReducer,
+      origination: originationReducer,
+      portfolio: portfolioReducer
+    }
+  });
+
+  return ({ children }: PropsWithChildren) => (
+    <Provider store={store}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </Provider>
+  );
+}
+
+describe('useComparativeDashboard', () => {
+  it('sincroniza dados carregados do dashboard', async () => {
+    const metrics = [{ metric: 'Cap Rate', subject: 0.1, benchmark: 0.08 }];
+    vi.mocked(api.fetchComparativeDashboard).mockResolvedValue(metrics);
+
+    const { result } = renderHook(() => useComparativeDashboard(), {
+      wrapper: createWrapper()
+    });
+
+    await waitFor(() => expect(result.current.metrics).toEqual(metrics));
+    expect(result.current.query.data).toEqual(metrics);
+  });
+});

--- a/src/features/analysis/hooks/useComparativeDashboard.ts
+++ b/src/features/analysis/hooks/useComparativeDashboard.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAppDispatch, useAppSelector } from '../../../app/hooks';
+import { fetchComparativeDashboard } from '../api';
+import { dashboardLoaded, selectAnalysisMetrics, selectRunningSimulation } from '../slice';
+
+export function useComparativeDashboard() {
+  const dispatch = useAppDispatch();
+  const metrics = useAppSelector(selectAnalysisMetrics);
+  const running = useAppSelector(selectRunningSimulation);
+
+  const query = useQuery({
+    queryKey: ['analysis', 'comparative-dashboard'],
+    queryFn: fetchComparativeDashboard,
+    onSuccess: (data) => dispatch(dashboardLoaded(data))
+  });
+
+  return { metrics, running, query };
+}

--- a/src/features/analysis/pages/__tests__/loader.test.ts
+++ b/src/features/analysis/pages/__tests__/loader.test.ts
@@ -1,0 +1,16 @@
+import { loader } from '../loader';
+import * as api from '../../api';
+
+vi.mock('../../api');
+
+describe('analysis loader', () => {
+  it('retorna métricas do dashboard', async () => {
+    const metrics = [{ metric: 'Cap Rate', subject: 0.1, benchmark: 0.08 }];
+    vi.mocked(api.fetchComparativeDashboard).mockResolvedValueOnce(metrics);
+
+    const result = await loader({} as any);
+
+    expect(api.fetchComparativeDashboard).toHaveBeenCalled();
+    expect(result).toEqual({ metrics });
+  });
+});

--- a/src/features/analysis/pages/index.tsx
+++ b/src/features/analysis/pages/index.tsx
@@ -1,0 +1,60 @@
+import { FormEvent, useState } from 'react';
+import { useAppDispatch } from '../../../app/hooks';
+import ComparativeTable from '../components/ComparativeTable';
+import { executeSimulation } from '../slice';
+import { useComparativeDashboard } from '../hooks/useComparativeDashboard';
+
+export function AnalysisRoot() {
+  const dispatch = useAppDispatch();
+  const [capital, setCapital] = useState(1_000_000);
+  const {
+    metrics,
+    running,
+    query: { isLoading, error }
+  } = useComparativeDashboard();
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    dispatch(
+      executeSimulation({
+        scenario: 'custom',
+        capital
+      })
+    );
+  };
+
+  return (
+    <section>
+      <header>
+        <h2>Dashboards Comparativos</h2>
+        <p>
+          Explore métricas-chave da carteira frente aos benchmarks de mercado e projete cenários para orientar
+          decisões estratégicas.
+        </p>
+      </header>
+
+      {isLoading && <p>Carregando métricas...</p>}
+      {error && <p data-testid="analysis-error">Erro ao carregar dashboard.</p>}
+
+      <ComparativeTable metrics={metrics} />
+
+      <form onSubmit={handleSubmit} style={{ marginTop: '1.5rem' }}>
+        <label>
+          Capital projetado (R$)
+          <input
+            type="number"
+            min="100000"
+            step="50000"
+            value={capital}
+            onChange={(event) => setCapital(Number(event.target.value))}
+          />
+        </label>
+        <button type="submit" disabled={running}>
+          {running ? 'Rodando simulação...' : 'Rodar simulação'}
+        </button>
+      </form>
+    </section>
+  );
+}
+
+export default AnalysisRoot;

--- a/src/features/analysis/pages/loader.ts
+++ b/src/features/analysis/pages/loader.ts
@@ -1,0 +1,7 @@
+import { LoaderFunctionArgs } from 'react-router-dom';
+import { fetchComparativeDashboard } from '../api';
+
+export async function loader(_args: LoaderFunctionArgs) {
+  const metrics = await fetchComparativeDashboard();
+  return { metrics };
+}

--- a/src/features/analysis/slice.ts
+++ b/src/features/analysis/slice.ts
@@ -1,0 +1,64 @@
+import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { RootState } from '../../app/store';
+import { ComparativeMetric, SimulationPayload, runScenario } from './api';
+
+export interface AnalysisState {
+  metrics: ComparativeMetric[];
+  runningSimulation: boolean;
+  optimisticSnapshot?: ComparativeMetric[];
+  error?: string;
+}
+
+const initialState: AnalysisState = {
+  metrics: [],
+  runningSimulation: false
+};
+
+export const executeSimulation = createAsyncThunk(
+  'analysis/executeSimulation',
+  async (payload: SimulationPayload) => {
+    const metrics = await runScenario(payload);
+    return { metrics };
+  }
+);
+
+const analysisSlice = createSlice({
+  name: 'analysis',
+  initialState,
+  reducers: {
+    dashboardLoaded(state, action: PayloadAction<ComparativeMetric[]>) {
+      state.metrics = action.payload;
+    }
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(executeSimulation.pending, (state, action) => {
+        state.runningSimulation = true;
+        state.error = undefined;
+        state.optimisticSnapshot = state.metrics;
+        state.metrics = state.metrics.map((metric) => ({
+          ...metric,
+          subject: metric.subject * (action.meta.arg.capital / 1_000_000)
+        }));
+      })
+      .addCase(executeSimulation.fulfilled, (state, action) => {
+        state.runningSimulation = false;
+        state.metrics = action.payload.metrics;
+        state.optimisticSnapshot = undefined;
+      })
+      .addCase(executeSimulation.rejected, (state, action) => {
+        state.runningSimulation = false;
+        state.error = action.error.message;
+        if (state.optimisticSnapshot) {
+          state.metrics = state.optimisticSnapshot;
+        }
+        state.optimisticSnapshot = undefined;
+      });
+  }
+});
+
+export const { dashboardLoaded } = analysisSlice.actions;
+export const analysisReducer = analysisSlice.reducer;
+
+export const selectAnalysisMetrics = (state: RootState) => state.analysis.metrics;
+export const selectRunningSimulation = (state: RootState) => state.analysis.runningSimulation;

--- a/src/features/origination/__tests__/slice.test.ts
+++ b/src/features/origination/__tests__/slice.test.ts
@@ -1,0 +1,39 @@
+import { originationReducer, pipelineLoaded, sendProposal } from '../slice';
+import { Opportunity } from '../api';
+
+describe('origination reducer', () => {
+  it('atualiza o pipeline quando carregado', () => {
+    const opportunities: Opportunity[] = [
+      { id: '1', propertyName: 'Imóvel', stage: 'prospect', expectedReturn: 0.12 }
+    ];
+    const state = originationReducer(undefined, pipelineLoaded(opportunities));
+
+    expect(state.pipeline).toEqual(opportunities);
+  });
+
+  it('aplica atualização otimista e consolida no sucesso', () => {
+    const baseState = originationReducer(
+      undefined,
+      pipelineLoaded([{ id: '1', propertyName: 'Imóvel', stage: 'analysis', expectedReturn: 0.12 }])
+    );
+
+    const pendingState = originationReducer(
+      baseState,
+      sendProposal.pending('request-1', { opportunityId: '1', offerValue: 1000 })
+    );
+
+    expect(pendingState.pipeline[0].stage).toBe('negotiation');
+
+    const fulfilledState = originationReducer(
+      pendingState,
+      sendProposal.fulfilled(
+        { id: '1', propertyName: 'Imóvel', stage: 'negotiation', expectedReturn: 0.15 },
+        'request-1',
+        { opportunityId: '1', offerValue: 1000 }
+      )
+    );
+
+    expect(fulfilledState.pipeline[0].expectedReturn).toBe(0.15);
+    expect(fulfilledState.optimisticSnapshot).toBeUndefined();
+  });
+});

--- a/src/features/origination/api/index.ts
+++ b/src/features/origination/api/index.ts
@@ -1,0 +1,42 @@
+export interface Opportunity {
+  id: string;
+  propertyName: string;
+  stage: 'prospect' | 'analysis' | 'offer' | 'negotiation';
+  expectedReturn: number;
+}
+
+export interface ProposalPayload {
+  opportunityId: string;
+  offerValue: number;
+}
+
+const mockPipeline: Opportunity[] = [
+  {
+    id: 'op-001',
+    propertyName: 'Residencial Aurora',
+    stage: 'analysis',
+    expectedReturn: 0.18
+  },
+  {
+    id: 'op-002',
+    propertyName: 'Complexo Horizonte',
+    stage: 'offer',
+    expectedReturn: 0.22
+  }
+];
+
+export async function fetchPipeline(): Promise<Opportunity[]> {
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  return mockPipeline;
+}
+
+export async function submitProposal(payload: ProposalPayload): Promise<Opportunity> {
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  const updated: Opportunity = {
+    id: payload.opportunityId,
+    propertyName: mockPipeline[0]?.propertyName ?? 'Nova oportunidade',
+    stage: 'negotiation',
+    expectedReturn: mockPipeline[0]?.expectedReturn ?? 0.18
+  };
+  return updated;
+}

--- a/src/features/origination/components/PipelineBoard.tsx
+++ b/src/features/origination/components/PipelineBoard.tsx
@@ -1,0 +1,34 @@
+import { Opportunity } from '../api';
+
+interface PipelineBoardProps {
+  opportunities: Opportunity[];
+}
+
+export function PipelineBoard({ opportunities }: PipelineBoardProps) {
+  if (!opportunities.length) {
+    return <p>Nenhuma oportunidade cadastrada no momento.</p>;
+  }
+
+  return (
+    <table className="pipeline-board">
+      <thead>
+        <tr>
+          <th>Imóvel</th>
+          <th>Estágio</th>
+          <th>Retorno Esperado</th>
+        </tr>
+      </thead>
+      <tbody>
+        {opportunities.map((opportunity) => (
+          <tr key={opportunity.id}>
+            <td>{opportunity.propertyName}</td>
+            <td>{opportunity.stage}</td>
+            <td>{(opportunity.expectedReturn * 100).toFixed(1)}%</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export default PipelineBoard;

--- a/src/features/origination/hooks/__tests__/useOriginationPipeline.test.tsx
+++ b/src/features/origination/hooks/__tests__/useOriginationPipeline.test.tsx
@@ -1,0 +1,47 @@
+import { PropsWithChildren } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import * as api from '../../api';
+import { useOriginationPipeline } from '../useOriginationPipeline';
+import { originationReducer } from '../../slice';
+import { analysisReducer } from '../../../analysis/slice';
+import { portfolioReducer } from '../../../portfolio/slice';
+
+vi.mock('../../api');
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, cacheTime: 0 } }
+  });
+  const store = configureStore({
+    reducer: {
+      origination: originationReducer,
+      analysis: analysisReducer,
+      portfolio: portfolioReducer
+    }
+  });
+
+  return ({ children }: PropsWithChildren) => (
+    <Provider store={store}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </Provider>
+  );
+}
+
+describe('useOriginationPipeline', () => {
+  it('carrega e expõe o pipeline sincronizado com o Redux', async () => {
+    const mockedPipeline = [
+      { id: '1', propertyName: 'Imóvel', stage: 'analysis', expectedReturn: 0.1 }
+    ];
+    vi.mocked(api.fetchPipeline).mockResolvedValue(mockedPipeline);
+
+    const { result } = renderHook(() => useOriginationPipeline(), {
+      wrapper: createWrapper()
+    });
+
+    await waitFor(() => expect(result.current.pipeline).toEqual(mockedPipeline));
+    expect(result.current.query.data).toEqual(mockedPipeline);
+  });
+});

--- a/src/features/origination/hooks/useOriginationPipeline.ts
+++ b/src/features/origination/hooks/useOriginationPipeline.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAppDispatch, useAppSelector } from '../../../app/hooks';
+import { fetchPipeline } from '../api';
+import { pipelineLoaded, selectOriginationPipeline, selectOriginationSubmitting } from '../slice';
+
+export function useOriginationPipeline() {
+  const dispatch = useAppDispatch();
+  const pipeline = useAppSelector(selectOriginationPipeline);
+  const submitting = useAppSelector(selectOriginationSubmitting);
+
+  const query = useQuery({
+    queryKey: ['origination', 'pipeline'],
+    queryFn: fetchPipeline,
+    onSuccess: (data) => dispatch(pipelineLoaded(data))
+  });
+
+  return {
+    pipeline,
+    submitting,
+    query
+  };
+}

--- a/src/features/origination/pages/__tests__/loader.test.ts
+++ b/src/features/origination/pages/__tests__/loader.test.ts
@@ -1,0 +1,18 @@
+import { loader } from '../loader';
+import * as api from '../../api';
+
+vi.mock('../../api');
+
+describe('origination loader', () => {
+  it('retorna o pipeline da API', async () => {
+    const mockedPipeline = [
+      { id: '1', propertyName: 'Teste', stage: 'analysis', expectedReturn: 0.1 }
+    ];
+    vi.mocked(api.fetchPipeline).mockResolvedValueOnce(mockedPipeline);
+
+    const result = await loader({} as any);
+
+    expect(api.fetchPipeline).toHaveBeenCalled();
+    expect(result).toEqual({ pipeline: mockedPipeline });
+  });
+});

--- a/src/features/origination/pages/index.tsx
+++ b/src/features/origination/pages/index.tsx
@@ -1,0 +1,47 @@
+import { useAppDispatch } from '../../../app/hooks';
+import PipelineBoard from '../components/PipelineBoard';
+import { sendProposal } from '../slice';
+import { useOriginationPipeline } from '../hooks/useOriginationPipeline';
+
+export function OriginationRoot() {
+  const dispatch = useAppDispatch();
+  const {
+    pipeline,
+    submitting,
+    query: { isLoading, error }
+  } = useOriginationPipeline();
+
+  const handleSendProposal = () => {
+    const target = pipeline[0];
+    if (!target) return;
+    dispatch(
+      sendProposal({
+        opportunityId: target.id,
+        offerValue: target.expectedReturn * 1000000
+      })
+    );
+  };
+
+  return (
+    <section>
+      <header>
+        <h2>Pipeline de Originação</h2>
+        <p>
+          Monitore oportunidades em andamento, acompanhe o funil de negociação e acelere o envio de propostas
+          para imóveis prioritários.
+        </p>
+      </header>
+
+      {isLoading && <p>Carregando oportunidades...</p>}
+      {error && <p data-testid="origination-error">Falha ao carregar pipeline.</p>}
+
+      <PipelineBoard opportunities={pipeline} />
+
+      <button type="button" onClick={handleSendProposal} disabled={!pipeline.length || submitting}>
+        {submitting ? 'Enviando proposta...' : 'Enviar proposta para destaque'}
+      </button>
+    </section>
+  );
+}
+
+export default OriginationRoot;

--- a/src/features/origination/pages/loader.ts
+++ b/src/features/origination/pages/loader.ts
@@ -1,0 +1,7 @@
+import { LoaderFunctionArgs } from 'react-router-dom';
+import { fetchPipeline } from '../api';
+
+export async function loader(_args: LoaderFunctionArgs) {
+  const pipeline = await fetchPipeline();
+  return { pipeline };
+}

--- a/src/features/origination/slice.ts
+++ b/src/features/origination/slice.ts
@@ -1,0 +1,67 @@
+import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { RootState } from '../../app/store';
+import { Opportunity, ProposalPayload, submitProposal } from './api';
+
+export interface OriginationState {
+  pipeline: Opportunity[];
+  submitting: boolean;
+  optimisticSnapshot?: Opportunity[];
+  error?: string;
+}
+
+const initialState: OriginationState = {
+  pipeline: [],
+  submitting: false
+};
+
+export const sendProposal = createAsyncThunk(
+  'origination/sendProposal',
+  async (payload: ProposalPayload) => {
+    const response = await submitProposal(payload);
+    return response;
+  }
+);
+
+const originationSlice = createSlice({
+  name: 'origination',
+  initialState,
+  reducers: {
+    pipelineLoaded(state, action: PayloadAction<Opportunity[]>) {
+      state.pipeline = action.payload;
+    }
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(sendProposal.pending, (state, action) => {
+        state.submitting = true;
+        state.error = undefined;
+        state.optimisticSnapshot = state.pipeline;
+        state.pipeline = state.pipeline.map((opportunity) =>
+          opportunity.id === action.meta.arg.opportunityId
+            ? { ...opportunity, stage: 'negotiation' }
+            : opportunity
+        );
+      })
+      .addCase(sendProposal.fulfilled, (state, action) => {
+        state.submitting = false;
+        state.pipeline = state.pipeline.map((opportunity) =>
+          opportunity.id === action.payload.id ? action.payload : opportunity
+        );
+        state.optimisticSnapshot = undefined;
+      })
+      .addCase(sendProposal.rejected, (state, action) => {
+        state.submitting = false;
+        state.error = action.error.message;
+        if (state.optimisticSnapshot) {
+          state.pipeline = state.optimisticSnapshot;
+        }
+        state.optimisticSnapshot = undefined;
+      });
+  }
+});
+
+export const { pipelineLoaded } = originationSlice.actions;
+export const originationReducer = originationSlice.reducer;
+
+export const selectOriginationPipeline = (state: RootState) => state.origination.pipeline;
+export const selectOriginationSubmitting = (state: RootState) => state.origination.submitting;

--- a/src/features/portfolio/__tests__/slice.test.ts
+++ b/src/features/portfolio/__tests__/slice.test.ts
@@ -1,0 +1,40 @@
+import { portfolioReducer, portfolioLoaded, adjustAlerts } from '../slice';
+import { AssetSnapshot } from '../api';
+
+describe('portfolio reducer', () => {
+  it('carrega ativos consolidados', () => {
+    const assets: AssetSnapshot[] = [
+      { id: '1', name: 'Ativo', allocation: 0.2, riskLevel: 'baixo' }
+    ];
+
+    const state = portfolioReducer(undefined, portfolioLoaded(assets));
+
+    expect(state.assets).toEqual(assets);
+  });
+
+  it('realiza atualização otimista ao ajustar alertas', () => {
+    const baseState = portfolioReducer(
+      undefined,
+      portfolioLoaded([{ id: '1', name: 'Ativo', allocation: 0.2, riskLevel: 'baixo' }])
+    );
+
+    const pending = portfolioReducer(
+      baseState,
+      adjustAlerts.pending('alert-1', { assetId: '1', threshold: 45 })
+    );
+
+    expect(pending.assets[0].allocation).toBeCloseTo(0.45);
+
+    const fulfilled = portfolioReducer(
+      pending,
+      adjustAlerts.fulfilled(
+        { id: '1', name: 'Ativo', allocation: 0.5, riskLevel: 'alto' },
+        'alert-1',
+        { assetId: '1', threshold: 45 }
+      )
+    );
+
+    expect(fulfilled.assets[0].allocation).toBe(0.5);
+    expect(fulfilled.optimisticSnapshot).toBeUndefined();
+  });
+});

--- a/src/features/portfolio/api/index.ts
+++ b/src/features/portfolio/api/index.ts
@@ -1,0 +1,34 @@
+export interface AssetSnapshot {
+  id: string;
+  name: string;
+  allocation: number;
+  riskLevel: 'baixo' | 'médio' | 'alto';
+}
+
+export interface AlertAdjustmentPayload {
+  assetId: string;
+  threshold: number;
+}
+
+const mockPortfolio: AssetSnapshot[] = [
+  { id: 'asset-01', name: 'FII Proptech', allocation: 0.32, riskLevel: 'médio' },
+  { id: 'asset-02', name: 'Residencial Atlântico', allocation: 0.21, riskLevel: 'baixo' }
+];
+
+export async function fetchPortfolioOverview(): Promise<AssetSnapshot[]> {
+  await new Promise((resolve) => setTimeout(resolve, 60));
+  return mockPortfolio;
+}
+
+export async function adjustAlertThreshold(payload: AlertAdjustmentPayload): Promise<AssetSnapshot> {
+  await new Promise((resolve) => setTimeout(resolve, 60));
+  const target = mockPortfolio.find((asset) => asset.id === payload.assetId);
+  return (
+    target ?? {
+      id: payload.assetId,
+      name: 'Novo ativo',
+      allocation: payload.threshold / 100,
+      riskLevel: 'médio'
+    }
+  );
+}

--- a/src/features/portfolio/components/PortfolioSummary.tsx
+++ b/src/features/portfolio/components/PortfolioSummary.tsx
@@ -1,0 +1,29 @@
+import { AssetSnapshot } from '../api';
+
+interface PortfolioSummaryProps {
+  assets: AssetSnapshot[];
+}
+
+export function PortfolioSummary({ assets }: PortfolioSummaryProps) {
+  if (!assets.length) {
+    return <p>Carteira ainda não possui ativos monitorados.</p>;
+  }
+
+  const totalAllocation = assets.reduce((sum, asset) => sum + asset.allocation, 0);
+
+  return (
+    <div className="portfolio-summary">
+      <h3>Alocação Consolidada</h3>
+      <p>Total alocado: {(totalAllocation * 100).toFixed(1)}%</p>
+      <ul>
+        {assets.map((asset) => (
+          <li key={asset.id}>
+            <strong>{asset.name}</strong> — {(asset.allocation * 100).toFixed(1)}% • risco {asset.riskLevel}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default PortfolioSummary;

--- a/src/features/portfolio/hooks/__tests__/usePortfolioOverview.test.tsx
+++ b/src/features/portfolio/hooks/__tests__/usePortfolioOverview.test.tsx
@@ -1,0 +1,43 @@
+import { PropsWithChildren } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import * as api from '../../api';
+import { usePortfolioOverview } from '../usePortfolioOverview';
+import { portfolioReducer } from '../../slice';
+import { analysisReducer } from '../../../analysis/slice';
+import { originationReducer } from '../../../origination/slice';
+
+vi.mock('../../api');
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, cacheTime: 0 } } });
+  const store = configureStore({
+    reducer: {
+      portfolio: portfolioReducer,
+      analysis: analysisReducer,
+      origination: originationReducer
+    }
+  });
+
+  return ({ children }: PropsWithChildren) => (
+    <Provider store={store}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </Provider>
+  );
+}
+
+describe('usePortfolioOverview', () => {
+  it('retorna carteira consolidada via React Query', async () => {
+    const assets = [{ id: '1', name: 'Ativo', allocation: 0.4, riskLevel: 'baixo' as const }];
+    vi.mocked(api.fetchPortfolioOverview).mockResolvedValue(assets);
+
+    const { result } = renderHook(() => usePortfolioOverview(), {
+      wrapper: createWrapper()
+    });
+
+    await waitFor(() => expect(result.current.assets).toEqual(assets));
+    expect(result.current.query.data).toEqual(assets);
+  });
+});

--- a/src/features/portfolio/hooks/usePortfolioOverview.ts
+++ b/src/features/portfolio/hooks/usePortfolioOverview.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAppDispatch, useAppSelector } from '../../../app/hooks';
+import { fetchPortfolioOverview } from '../api';
+import { portfolioLoaded, selectPortfolioAssets, selectUpdatingAlert } from '../slice';
+
+export function usePortfolioOverview() {
+  const dispatch = useAppDispatch();
+  const assets = useAppSelector(selectPortfolioAssets);
+  const updatingAlert = useAppSelector(selectUpdatingAlert);
+
+  const query = useQuery({
+    queryKey: ['portfolio', 'overview'],
+    queryFn: fetchPortfolioOverview,
+    onSuccess: (data) => dispatch(portfolioLoaded(data))
+  });
+
+  return { assets, updatingAlert, query };
+}

--- a/src/features/portfolio/pages/__tests__/loader.test.ts
+++ b/src/features/portfolio/pages/__tests__/loader.test.ts
@@ -1,0 +1,16 @@
+import { loader } from '../loader';
+import * as api from '../../api';
+
+vi.mock('../../api');
+
+describe('portfolio loader', () => {
+  it('retorna visão consolidada', async () => {
+    const assets = [{ id: '1', name: 'Ativo', allocation: 0.2, riskLevel: 'baixo' as const }];
+    vi.mocked(api.fetchPortfolioOverview).mockResolvedValueOnce(assets);
+
+    const result = await loader({} as any);
+
+    expect(api.fetchPortfolioOverview).toHaveBeenCalled();
+    expect(result).toEqual({ assets });
+  });
+});

--- a/src/features/portfolio/pages/index.tsx
+++ b/src/features/portfolio/pages/index.tsx
@@ -1,0 +1,65 @@
+import { FormEvent, useState } from 'react';
+import { useAppDispatch } from '../../../app/hooks';
+import PortfolioSummary from '../components/PortfolioSummary';
+import { adjustAlerts } from '../slice';
+import { usePortfolioOverview } from '../hooks/usePortfolioOverview';
+
+export function PortfolioRoot() {
+  const dispatch = useAppDispatch();
+  const [assetId, setAssetId] = useState('asset-01');
+  const [threshold, setThreshold] = useState(30);
+  const {
+    assets,
+    updatingAlert,
+    query: { isLoading, error }
+  } = usePortfolioOverview();
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    dispatch(
+      adjustAlerts({
+        assetId,
+        threshold
+      })
+    );
+  };
+
+  return (
+    <section>
+      <header>
+        <h2>Visão Consolidada da Carteira</h2>
+        <p>
+          Acompanhe a alocação, sensibilidade de risco e configure alertas para proteger a performance da sua
+          carteira imobiliária.
+        </p>
+      </header>
+
+      {isLoading && <p>Carregando carteira...</p>}
+      {error && <p data-testid="portfolio-error">Não foi possível carregar a carteira.</p>}
+
+      <PortfolioSummary assets={assets} />
+
+      <form onSubmit={handleSubmit} style={{ marginTop: '1.5rem' }}>
+        <label>
+          Ativo monitorado
+          <input value={assetId} onChange={(event) => setAssetId(event.target.value)} />
+        </label>
+        <label>
+          Limite de alerta (%)
+          <input
+            type="number"
+            min="10"
+            max="100"
+            value={threshold}
+            onChange={(event) => setThreshold(Number(event.target.value))}
+          />
+        </label>
+        <button type="submit" disabled={updatingAlert}>
+          {updatingAlert ? 'Atualizando alertas...' : 'Ajustar alertas'}
+        </button>
+      </form>
+    </section>
+  );
+}
+
+export default PortfolioRoot;

--- a/src/features/portfolio/pages/loader.ts
+++ b/src/features/portfolio/pages/loader.ts
@@ -1,0 +1,7 @@
+import { LoaderFunctionArgs } from 'react-router-dom';
+import { fetchPortfolioOverview } from '../api';
+
+export async function loader(_args: LoaderFunctionArgs) {
+  const assets = await fetchPortfolioOverview();
+  return { assets };
+}

--- a/src/features/portfolio/slice.ts
+++ b/src/features/portfolio/slice.ts
@@ -1,0 +1,79 @@
+import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { RootState } from '../../app/store';
+import { adjustAlertThreshold, AlertAdjustmentPayload, AssetSnapshot } from './api';
+
+export interface PortfolioState {
+  assets: AssetSnapshot[];
+  updatingAlert: boolean;
+  optimisticSnapshot?: AssetSnapshot[];
+  error?: string;
+}
+
+const initialState: PortfolioState = {
+  assets: [],
+  updatingAlert: false
+};
+
+export const adjustAlerts = createAsyncThunk(
+  'portfolio/adjustAlerts',
+  async (payload: AlertAdjustmentPayload) => {
+    const asset = await adjustAlertThreshold(payload);
+    return asset;
+  }
+);
+
+const portfolioSlice = createSlice({
+  name: 'portfolio',
+  initialState,
+  reducers: {
+    portfolioLoaded(state, action: PayloadAction<AssetSnapshot[]>) {
+      state.assets = action.payload;
+    }
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(adjustAlerts.pending, (state, action) => {
+        state.updatingAlert = true;
+        state.error = undefined;
+        state.optimisticSnapshot = state.assets;
+        const { assetId, threshold } = action.meta.arg;
+        const exists = state.assets.some((asset) => asset.id === assetId);
+        if (exists) {
+          state.assets = state.assets.map((asset) =>
+            asset.id === assetId ? { ...asset, allocation: threshold / 100 } : asset
+          );
+        } else {
+          state.assets = [
+            ...state.assets,
+            {
+              id: assetId,
+              name: 'Novo ativo',
+              allocation: threshold / 100,
+              riskLevel: 'médio'
+            }
+          ];
+        }
+      })
+      .addCase(adjustAlerts.fulfilled, (state, action) => {
+        state.updatingAlert = false;
+        state.assets = state.assets.map((asset) =>
+          asset.id === action.payload.id ? action.payload : asset
+        );
+        state.optimisticSnapshot = undefined;
+      })
+      .addCase(adjustAlerts.rejected, (state, action) => {
+        state.updatingAlert = false;
+        state.error = action.error.message;
+        if (state.optimisticSnapshot) {
+          state.assets = state.optimisticSnapshot;
+        }
+        state.optimisticSnapshot = undefined;
+      });
+  }
+});
+
+export const { portfolioLoaded } = portfolioSlice.actions;
+export const portfolioReducer = portfolioSlice.reducer;
+
+export const selectPortfolioAssets = (state: RootState) => state.portfolio.assets;
+export const selectUpdatingAlert = (state: RootState) => state.portfolio.updatingAlert;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { RouterProvider } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { store } from './app/store';
+import { router } from './app/router';
+
+const queryClient = new QueryClient();
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <Provider store={store}>
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
+    </Provider>
+  </React.StrictMode>
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './vitest.setup.ts'
+  }
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
## Summary
- scaffold Vite + React workspace and domain oriented feature folders
- add lazy loaded routes with React Query hooks and Redux slices for origination, analysis and portfolio
- provide optimistic thunks, API stubs and unit tests for loaders, reducers and hooks

## Testing
- npm test *(fails: vitest command not found – dependencies could not be installed because the npm registry forbids scoped packages such as @reduxjs/toolkit)*

------
https://chatgpt.com/codex/tasks/task_b_68cdd5f17e388326a591cfb02b474729