### PR TITLE
feat: add primary navigation and portfolio selector

### DIFF
--- a/src/app/AppShell.css
+++ b/src/app/AppShell.css
@@ -8,17 +8,129 @@
 
 .app-shell__header {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  justify-content: space-between;
+  gap: 1rem 1.5rem;
   padding: 1rem 1.5rem;
   border-bottom: 1px solid rgba(148, 163, 184, 0.2);
-  background: rgba(15, 23, 42, 0.8);
+  background: rgba(15, 23, 42, 0.85);
   backdrop-filter: blur(16px);
 }
 
 .app-shell__brand {
   font-size: 1.25rem;
   font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.app-shell__nav {
+  order: 3;
+  flex: 1 1 100%;
+  overflow-x: auto;
+  padding-bottom: 0.25rem;
+  -webkit-overflow-scrolling: touch;
+}
+
+.app-shell__nav-list {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  min-width: fit-content;
+}
+
+.app-shell__nav-item {
+  flex: 0 0 auto;
+}
+
+.app-shell__nav-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #e2e8f0;
+  background: rgba(30, 41, 59, 0.6);
+  border: 1px solid transparent;
+  text-decoration: none;
+  transition: color 150ms ease, background 150ms ease, box-shadow 150ms ease,
+    border-color 150ms ease;
+}
+
+.app-shell__nav-link:hover {
+  color: #f8fafc;
+  border-color: rgba(148, 163, 184, 0.35);
+  box-shadow: 0 8px 20px rgba(15, 118, 110, 0.25);
+}
+
+.app-shell__nav-link:focus-visible {
+  outline: 2px solid #38bdf8;
+  outline-offset: 3px;
+}
+
+.app-shell__nav-link--active {
+  color: #0f172a;
+  background: linear-gradient(135deg, #22d3ee, #2dd4bf);
+  border-color: transparent;
+  box-shadow: 0 12px 30px rgba(45, 212, 191, 0.35);
+}
+
+.app-shell__nav-link--active:hover {
+  color: #021427;
+}
+
+.app-shell__controls {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  flex: 1 1 100%;
+  order: 2;
+  flex-wrap: wrap;
+}
+
+.app-shell__portfolio {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  flex: 1 1 100%;
+  min-width: 12rem;
+}
+
+.app-shell__portfolio-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.app-shell__portfolio-select {
+  appearance: none;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.65);
+  color: #f8fafc;
+  padding: 0.55rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.2;
+  transition: border-color 150ms ease, box-shadow 150ms ease,
+    background 150ms ease;
+}
+
+.app-shell__portfolio-select:hover {
+  border-color: rgba(125, 211, 252, 0.6);
+}
+
+.app-shell__portfolio-select:focus-visible {
+  outline: 2px solid #38bdf8;
+  outline-offset: 3px;
+  border-color: transparent;
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.35);
 }
 
 .app-shell__alerts-toggle {
@@ -26,11 +138,12 @@
   border-radius: 999px;
   padding: 0.5rem 1rem;
   font-size: 0.875rem;
-  font-weight: 500;
+  font-weight: 600;
   background: linear-gradient(135deg, #0ea5e9, #22d3ee);
   color: #0f172a;
   cursor: pointer;
   transition: transform 150ms ease, box-shadow 150ms ease;
+  white-space: nowrap;
 }
 
 .app-shell__alerts-toggle:focus-visible {
@@ -150,6 +263,31 @@
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
+}
+
+@media (min-width: 48rem) {
+  .app-shell__header {
+    flex-wrap: nowrap;
+  }
+
+  .app-shell__nav {
+    order: 2;
+    flex: 1 1 auto;
+    padding-bottom: 0;
+  }
+
+  .app-shell__nav-list {
+    flex-wrap: nowrap;
+  }
+
+  .app-shell__controls {
+    order: 3;
+    flex: 0 0 auto;
+  }
+
+  .app-shell__portfolio {
+    flex: 0 0 16rem;
+  }
 }
 
 @media (max-width: 64rem) {

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -1,26 +1,120 @@
-import { PropsWithChildren, useId, useState } from 'react';
+import { PropsWithChildren, useEffect, useId, useState } from 'react';
 import './AppShell.css';
 
 export type AppShellProps = PropsWithChildren;
 
+const DOMAINS = [
+  { label: 'Originação de Negócios', path: '/originacao' },
+  { label: 'Análise e Valuation', path: '/analise' },
+  { label: 'Gestão de Portfólio', path: '/gestao' },
+] as const;
+
+const PORTFOLIO_OPTIONS = [
+  { label: 'Todos os Portfólios', value: 'all' },
+  { label: 'Fundo Tático FIIs', value: 'fiis-tatico' },
+  { label: 'Residencial Premium', value: 'residencial-premium' },
+  { label: 'Logística Norte', value: 'logistica-norte' },
+] as const;
+
+const PORTFOLIO_STORAGE_KEY = 'prop-stream:selected-portfolio';
+
 export function AppShell({ children }: AppShellProps) {
   const [isOpen, setIsOpen] = useState(false);
   const alertsTitleId = useId();
+  const portfolioLabelId = useId();
+  const [selectedPortfolio, setSelectedPortfolio] = useState(() => {
+    if (typeof window === 'undefined') {
+      return PORTFOLIO_OPTIONS[0]?.value ?? '';
+    }
+
+    return (
+      window.localStorage.getItem(PORTFOLIO_STORAGE_KEY) ??
+      (PORTFOLIO_OPTIONS[0]?.value ?? '')
+    );
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !selectedPortfolio) {
+      return;
+    }
+
+    window.localStorage.setItem(
+      PORTFOLIO_STORAGE_KEY,
+      selectedPortfolio
+    );
+  }, [selectedPortfolio]);
+
+  const currentPath =
+    typeof window !== 'undefined' ? window.location.pathname : '/';
 
   return (
     <div className="app-shell">
       <header className="app-shell__header">
         <div className="app-shell__brand">Prop-Stream</div>
-        <button
-          type="button"
-          className="app-shell__alerts-toggle"
-          aria-pressed={isOpen}
-          aria-expanded={isOpen}
-          aria-controls="app-shell-alerts"
-          onClick={() => setIsOpen((previous) => !previous)}
-        >
-          {isOpen ? 'Fechar alertas' : 'Abrir alertas'}
-        </button>
+        <nav className="app-shell__nav" aria-label="Navegação principal">
+          <ul
+            className="app-shell__nav-list"
+            role="menubar"
+            aria-orientation="horizontal"
+          >
+            {DOMAINS.map((domain) => {
+              const isActive =
+                currentPath === domain.path ||
+                currentPath.startsWith(`${domain.path}/`);
+
+              return (
+                <li
+                  key={domain.path}
+                  role="none"
+                  className="app-shell__nav-item"
+                >
+                  <a
+                    href={domain.path}
+                    role="menuitem"
+                    className={`app-shell__nav-link${
+                      isActive ? ' app-shell__nav-link--active' : ''
+                    }`}
+                    aria-current={isActive ? 'page' : undefined}
+                  >
+                    {domain.label}
+                  </a>
+                </li>
+              );
+            })}
+          </ul>
+        </nav>
+        <div className="app-shell__controls">
+          <div className="app-shell__portfolio">
+            <label
+              htmlFor={portfolioLabelId}
+              className="app-shell__portfolio-label"
+            >
+              Portfólio ativo
+            </label>
+            <select
+              id={portfolioLabelId}
+              className="app-shell__portfolio-select"
+              value={selectedPortfolio}
+              onChange={(event) => setSelectedPortfolio(event.target.value)}
+            >
+              {PORTFOLIO_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <button
+            type="button"
+            className="app-shell__alerts-toggle"
+            aria-pressed={isOpen}
+            aria-expanded={isOpen}
+            aria-controls="app-shell-alerts"
+            onClick={() => setIsOpen((previous) => !previous)}
+          >
+            {isOpen ? 'Fechar alertas' : 'Abrir alertas'}
+          </button>
+        </div>
       </header>
 
       <div


### PR DESCRIPTION
## Summary
- add primary navigation links for each functional domain with active page state and accessibility roles
- introduce a persistent portfolio selector stored in localStorage so the header keeps the user choice
- refresh the app shell header styling to accommodate navigation and controls across responsive breakpoints

## Testing
- npm run lint *(fails: repository still relies on .eslintrc.cjs and ESLint 9 requires the new flat config format)*
- npm run test -- --run *(fails: vitest binary unavailable because npm registry access is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cdf3ce37f0832698831b164781ea87