### PR TITLE
feat: add domain routing with lazy loaded modules

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -21,3 +21,9 @@
   max-width: 32rem;
   margin: 0;
 }
+
+.app-loading {
+  padding: 2rem;
+  text-align: center;
+  color: #0f172a;
+}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,11 +1,17 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 
+import { MemoryRouter } from 'react-router-dom';
+
 import App from './App';
 
 describe('App', () => {
   it('renderiza o título principal', () => {
-    render(<App />);
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>,
+    );
     expect(screen.getByRole('heading', { name: /prop-stream/i })).toBeInTheDocument();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,35 @@
+import { Suspense, lazy } from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
+
 import './App.css';
 import AppShell from './app/AppShell';
 
+const OriginationDomain = lazy(() => import('./domains/originacao'));
+const AnalysisDomain = lazy(() => import('./domains/analise'));
+const PortfolioDomain = lazy(() => import('./domains/gestao'));
+
+function HomePage() {
+  return (
+    <section className="app">
+      <h1>Prop-Stream</h1>
+      <p>Seu cockpit inteligente para investimentos imobiliários.</p>
+    </section>
+  );
+}
+
 function App() {
   return (
-    <AppShell>
-      <section className="app">
-        <h1>Prop-Stream</h1>
-        <p>Seu cockpit inteligente para investimentos imobiliários.</p>
-      </section>
-    </AppShell>
+    <Suspense fallback={<div className="app-loading">Carregando módulo...</div>}>
+      <Routes>
+        <Route path="/" element={<AppShell />}>
+          <Route index element={<HomePage />} />
+          <Route path="origination/*" element={<OriginationDomain />} />
+          <Route path="analysis/*" element={<AnalysisDomain />} />
+          <Route path="portfolio/*" element={<PortfolioDomain />} />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Route>
+      </Routes>
+    </Suspense>
   );
 }
 

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -1,12 +1,11 @@
-import { PropsWithChildren, useEffect, useId, useState } from 'react';
+import { useEffect, useId, useState } from 'react';
+import { NavLink, Outlet } from 'react-router-dom';
 import './AppShell.css';
 
-export type AppShellProps = PropsWithChildren;
-
 const DOMAINS = [
-  { label: 'Originação de Negócios', path: '/originacao' },
-  { label: 'Análise e Valuation', path: '/analise' },
-  { label: 'Gestão de Portfólio', path: '/gestao' },
+  { label: 'Originação de Negócios', path: '/origination' },
+  { label: 'Análise e Valuation', path: '/analysis' },
+  { label: 'Gestão de Portfólio', path: '/portfolio' },
 ] as const;
 
 const PORTFOLIO_OPTIONS = [
@@ -18,7 +17,7 @@ const PORTFOLIO_OPTIONS = [
 
 const PORTFOLIO_STORAGE_KEY = 'prop-stream:selected-portfolio';
 
-export function AppShell({ children }: AppShellProps) {
+export function AppShell() {
   const [isOpen, setIsOpen] = useState(false);
   const alertsTitleId = useId();
   const portfolioLabelId = useId();
@@ -43,10 +42,6 @@ export function AppShell({ children }: AppShellProps) {
       selectedPortfolio
     );
   }, [selectedPortfolio]);
-
-  const currentPath =
-    typeof window !== 'undefined' ? window.location.pathname : '/';
-
   return (
     <div className="app-shell">
       <header className="app-shell__header">
@@ -57,30 +52,21 @@ export function AppShell({ children }: AppShellProps) {
             role="menubar"
             aria-orientation="horizontal"
           >
-            {DOMAINS.map((domain) => {
-              const isActive =
-                currentPath === domain.path ||
-                currentPath.startsWith(`${domain.path}/`);
-
-              return (
-                <li
-                  key={domain.path}
-                  role="none"
-                  className="app-shell__nav-item"
-                >
-                  <a
-                    href={domain.path}
-                    role="menuitem"
-                    className={`app-shell__nav-link${
+            {DOMAINS.map((domain) => (
+              <li key={domain.path} role="none" className="app-shell__nav-item">
+                <NavLink
+                  to={domain.path}
+                  role="menuitem"
+                  className={({ isActive }) =>
+                    `app-shell__nav-link${
                       isActive ? ' app-shell__nav-link--active' : ''
-                    }`}
-                    aria-current={isActive ? 'page' : undefined}
-                  >
-                    {domain.label}
-                  </a>
-                </li>
-              );
-            })}
+                    }`
+                  }
+                >
+                  {domain.label}
+                </NavLink>
+              </li>
+            ))}
           </ul>
         </nav>
         <div className="app-shell__controls">
@@ -123,7 +109,7 @@ export function AppShell({ children }: AppShellProps) {
         }`}
       >
         <main className="app-shell__main" role="main">
-          {children}
+          <Outlet />
         </main>
 
         <aside

--- a/src/domains/analise/index.tsx
+++ b/src/domains/analise/index.tsx
@@ -1,0 +1,99 @@
+import { NavLink, Outlet, Route, Routes } from 'react-router-dom';
+
+type NavigationLink = {
+  readonly label: string;
+  readonly to: string;
+  readonly end?: boolean;
+};
+
+const LINKS: NavigationLink[] = [
+  { label: 'Visão geral', to: '.', end: true },
+  { label: 'Modelagem de valuation', to: 'modelagem' },
+  { label: 'Cenários e sensibilidade', to: 'cenarios' },
+];
+
+function AnalysisLayout() {
+  return (
+    <section className="domain domain--analysis">
+      <header className="domain__header">
+        <h1>Análise e Valuation</h1>
+        <p>
+          Construa modelos financeiros avançados, compare hipóteses e valide o
+          retorno esperado antes de cada investimento.
+        </p>
+      </header>
+
+      <nav className="domain__nav" aria-label="Sessões de análise">
+        <ul className="domain__nav-list">
+          {LINKS.map((link) => (
+            <li key={link.to} className="domain__nav-item">
+              <NavLink
+                to={link.to}
+                end={link.end}
+                className={({ isActive }) =>
+                  `domain__nav-link${
+                    isActive ? ' domain__nav-link--active' : ''
+                  }`
+                }
+              >
+                {link.label}
+              </NavLink>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      <div className="domain__content">
+        <Outlet />
+      </div>
+    </section>
+  );
+}
+
+function AnalysisOverview() {
+  return (
+    <article className="domain__section">
+      <h2>Indicadores de análise</h2>
+      <p>
+        Consulte rapidamente fluxo de caixa descontado, cap rates e métricas de
+        risco para cada ativo em avaliação.
+      </p>
+    </article>
+  );
+}
+
+function AnalysisValuation() {
+  return (
+    <article className="domain__section">
+      <h2>Modelagem de valuation</h2>
+      <p>
+        Configure parâmetros, taxas e premissas de saída para projetar cenários
+        otimizados de retorno financeiro e validar o preço-alvo de aquisição.
+      </p>
+    </article>
+  );
+}
+
+function AnalysisScenarios() {
+  return (
+    <article className="domain__section">
+      <h2>Cenários e sensibilidade</h2>
+      <p>
+        Simule choques de mercado, alterações de vacância e custos operacionais
+        para entender o impacto nas métricas principais de desempenho.
+      </p>
+    </article>
+  );
+}
+
+export default function AnalysisDomain() {
+  return (
+    <Routes>
+      <Route element={<AnalysisLayout />}>
+        <Route index element={<AnalysisOverview />} />
+        <Route path="modelagem" element={<AnalysisValuation />} />
+        <Route path="cenarios" element={<AnalysisScenarios />} />
+      </Route>
+    </Routes>
+  );
+}

--- a/src/domains/gestao/index.tsx
+++ b/src/domains/gestao/index.tsx
@@ -1,0 +1,99 @@
+import { NavLink, Outlet, Route, Routes } from 'react-router-dom';
+
+type NavigationLink = {
+  readonly label: string;
+  readonly to: string;
+  readonly end?: boolean;
+};
+
+const LINKS: NavigationLink[] = [
+  { label: 'Visão geral', to: '.', end: true },
+  { label: 'Distribuição de portfólio', to: 'distribuicao' },
+  { label: 'Indicadores operacionais', to: 'indicadores' },
+];
+
+function PortfolioLayout() {
+  return (
+    <section className="domain domain--portfolio">
+      <header className="domain__header">
+        <h1>Gestão de Portfólio</h1>
+        <p>
+          Acompanhe KPIs operacionais, desempenho financeiro e metas de cada
+          veículo de investimento imobiliário.
+        </p>
+      </header>
+
+      <nav className="domain__nav" aria-label="Sessões de gestão de portfólio">
+        <ul className="domain__nav-list">
+          {LINKS.map((link) => (
+            <li key={link.to} className="domain__nav-item">
+              <NavLink
+                to={link.to}
+                end={link.end}
+                className={({ isActive }) =>
+                  `domain__nav-link${
+                    isActive ? ' domain__nav-link--active' : ''
+                  }`
+                }
+              >
+                {link.label}
+              </NavLink>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      <div className="domain__content">
+        <Outlet />
+      </div>
+    </section>
+  );
+}
+
+function PortfolioOverview() {
+  return (
+    <article className="domain__section">
+      <h2>Visão consolidada</h2>
+      <p>
+        Monitore patrimônio líquido, distribuição geográfica e principais
+        eventos de cada portfólio sob gestão.
+      </p>
+    </article>
+  );
+}
+
+function PortfolioDistribution() {
+  return (
+    <article className="domain__section">
+      <h2>Distribuição de portfólio</h2>
+      <p>
+        Analise a composição dos ativos por classe, estágio de desenvolvimento e
+        alocação prevista versus realizada.
+      </p>
+    </article>
+  );
+}
+
+function PortfolioIndicators() {
+  return (
+    <article className="domain__section">
+      <h2>Indicadores operacionais</h2>
+      <p>
+        Acompanhe ocupação, inadimplência e despesas recorrentes para agir
+        rapidamente sobre ativos fora da meta.
+      </p>
+    </article>
+  );
+}
+
+export default function PortfolioDomain() {
+  return (
+    <Routes>
+      <Route element={<PortfolioLayout />}>
+        <Route index element={<PortfolioOverview />} />
+        <Route path="distribuicao" element={<PortfolioDistribution />} />
+        <Route path="indicadores" element={<PortfolioIndicators />} />
+      </Route>
+    </Routes>
+  );
+}

--- a/src/domains/originacao/index.tsx
+++ b/src/domains/originacao/index.tsx
@@ -1,0 +1,100 @@
+import { NavLink, Outlet, Route, Routes } from 'react-router-dom';
+
+type NavigationLink = {
+  readonly label: string;
+  readonly to: string;
+  readonly end?: boolean;
+};
+
+const LINKS: NavigationLink[] = [
+  { label: 'Visão geral', to: '.', end: true },
+  { label: 'Pipeline de negócios', to: 'pipeline' },
+  { label: 'Relatórios e indicadores', to: 'relatorios' },
+];
+
+function OriginationLayout() {
+  return (
+    <section className="domain domain--origination">
+      <header className="domain__header">
+        <h1>Originação de Negócios</h1>
+        <p>
+          Gerencie o funil de prospecção, organize oportunidades e acompanhe a
+          performance das equipes comerciais em tempo real.
+        </p>
+      </header>
+
+      <nav className="domain__nav" aria-label="Sessões de originação">
+        <ul className="domain__nav-list">
+          {LINKS.map((link) => (
+            <li key={link.to} className="domain__nav-item">
+              <NavLink
+                to={link.to}
+                end={link.end}
+                className={({ isActive }) =>
+                  `domain__nav-link${
+                    isActive ? ' domain__nav-link--active' : ''
+                  }`
+                }
+              >
+                {link.label}
+              </NavLink>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      <div className="domain__content">
+        <Outlet />
+      </div>
+    </section>
+  );
+}
+
+function OriginationOverview() {
+  return (
+    <article className="domain__section">
+      <h2>Resumo das captações</h2>
+      <p>
+        Visualize os indicadores críticos da originação, como volume captado
+        por região, taxa de conversão por etapa e oportunidades com prioridade
+        máxima.
+      </p>
+    </article>
+  );
+}
+
+function OriginationPipeline() {
+  return (
+    <article className="domain__section">
+      <h2>Pipeline de negócios</h2>
+      <p>
+        Consolide oportunidades por estágio, identifique gargalos e acompanhe
+        responsáveis com atraso para garantir a fluidez do funil.
+      </p>
+    </article>
+  );
+}
+
+function OriginationReports() {
+  return (
+    <article className="domain__section">
+      <h2>Relatórios e indicadores</h2>
+      <p>
+        Gere relatórios personalizáveis com métricas de originação, taxas de
+        sucesso e performance comparativa entre períodos.
+      </p>
+    </article>
+  );
+}
+
+export default function OriginationDomain() {
+  return (
+    <Routes>
+      <Route element={<OriginationLayout />}>
+        <Route index element={<OriginationOverview />} />
+        <Route path="pipeline" element={<OriginationPipeline />} />
+        <Route path="relatorios" element={<OriginationReports />} />
+      </Route>
+    </Routes>
+  );
+}


### PR DESCRIPTION
## Summary
- configure the application router with lazy loaded domain routes mounted under the AppShell layout
- create origination, analysis, and portfolio domain modules with local navigation and nested sub-routes
- adapt the AppShell navigation to use NavLink/Outlet and add a loading fallback plus updated test harness

## Testing
- npm run test -- --runInBand *(fails: vitest not found because dependencies could not be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cdf70f4c2083268921d8e06a9ce865