### PR TITLE
feat: add http client, domain services, and realtime utilities

### DIFF
--- a/src/services/httpClient.ts
+++ b/src/services/httpClient.ts
@@ -1,0 +1,422 @@
+import axios, {
+  AxiosError,
+  AxiosHeaders,
+  AxiosInstance,
+  AxiosRequestConfig,
+  AxiosResponse,
+} from 'axios';
+
+export type AccessTokenProvider = () =>
+  | string
+  | null
+  | Promise<string | null>;
+
+export type RefreshTokenHandler = (error: AxiosError) => Promise<string | null>;
+
+export type UnauthorizedHandler = (error: HttpClientError) => void;
+
+export type HttpErrorHandler = (error: HttpClientError) => void;
+
+export interface RetryPolicy {
+  /** Número máximo de tentativas extras. */
+  retries?: number;
+  /**
+   * Função para calcular o intervalo entre tentativas em milissegundos.
+   * Recebe a contagem atual (começando em 1) e o erro original.
+   */
+  retryDelay?: (retryCount: number, error: AxiosError) => number;
+  /**
+   * Condição que determina se o erro deve ser reprocessado.
+   * Retorne `true` para permitir uma nova tentativa.
+   */
+  retryCondition?: (error: AxiosError) => boolean;
+}
+
+export interface HttpRequestConfig<TData = unknown>
+  extends AxiosRequestConfig<TData> {
+  /** Ignora a injeção automática do token de autenticação. */
+  skipAuth?: boolean;
+  /** Política de retry específica para a requisição. */
+  retry?: RetryPolicy;
+  /** @internal */
+  __retryCount?: number;
+  /** @internal */
+  __isAuthRetry?: boolean;
+}
+
+export interface HttpSuccessResponse<TData = unknown> {
+  data: TData;
+  status: number;
+  headers: Record<string, string>;
+}
+
+export interface HttpErrorPayload {
+  status?: number;
+  code?: string;
+  message: string;
+  details?: unknown;
+  isNetworkError: boolean;
+  isTimeout: boolean;
+  isCanceled: boolean;
+}
+
+export class HttpClientError extends Error implements HttpErrorPayload {
+  public readonly status?: number;
+
+  public readonly code?: string;
+
+  public readonly details?: unknown;
+
+  public readonly isNetworkError: boolean;
+
+  public readonly isTimeout: boolean;
+
+  public readonly isCanceled: boolean;
+
+  public readonly originalError: unknown;
+
+  constructor(payload: HttpErrorPayload & { originalError: unknown }) {
+    super(payload.message);
+    this.name = 'HttpClientError';
+    this.status = payload.status;
+    this.code = payload.code;
+    this.details = payload.details;
+    this.isNetworkError = payload.isNetworkError;
+    this.isTimeout = payload.isTimeout;
+    this.isCanceled = payload.isCanceled;
+    this.originalError = payload.originalError;
+  }
+}
+
+const DEFAULT_RETRY_POLICY: Required<RetryPolicy> = {
+  retries: 2,
+  retryDelay: (retryCount) =>
+    Math.min(1000 * Math.pow(2, retryCount - 1), 8000),
+  retryCondition: (error) => {
+    if (!error || typeof error !== 'object') {
+      return false;
+    }
+
+    if (axios.isCancel(error)) {
+      return false;
+    }
+
+    if (!error.response) {
+      return true;
+    }
+
+    const { status } = error.response;
+    return status >= 500 || status === 429;
+  },
+};
+
+let defaultRetryPolicy: Required<RetryPolicy> = { ...DEFAULT_RETRY_POLICY };
+
+const httpClient: AxiosInstance = axios.create({
+  baseURL: import.meta.env?.VITE_API_BASE_URL ?? '/api',
+  timeout: 30000,
+  withCredentials: true,
+});
+
+let accessTokenProvider: AccessTokenProvider = () => null;
+let refreshTokenHandler: RefreshTokenHandler | null = null;
+let unauthorizedHandler: UnauthorizedHandler | null = null;
+let httpErrorHandler: HttpErrorHandler | null = null;
+let refreshPromise: Promise<string | null> | null = null;
+
+function resolveAuthorizationHeader(token: string, config: HttpRequestConfig) {
+  if (!token) {
+    return;
+  }
+
+  const headers = config.headers;
+
+  if (headers && typeof (headers as AxiosHeaders).set === 'function') {
+    (headers as AxiosHeaders).set('Authorization', `Bearer ${token}`);
+    return;
+  }
+
+  const plainHeaders =
+    headers && typeof headers === 'object'
+      ? (headers as Record<string, unknown>)
+      : {};
+
+  config.headers = {
+    ...plainHeaders,
+    Authorization: `Bearer ${token}`,
+  };
+}
+
+function resolveErrorMessage(error: AxiosError): string {
+  const responseData = error.response?.data;
+
+  if (typeof responseData === 'string' && responseData.trim().length > 0) {
+    return responseData;
+  }
+
+  if (
+    responseData &&
+    typeof responseData === 'object' &&
+    !Array.isArray(responseData)
+  ) {
+    const dataRecord = responseData as Record<string, unknown>;
+    const possibleKeys = ['message', 'error', 'detail', 'title'];
+    for (const key of possibleKeys) {
+      const value = dataRecord[key];
+      if (typeof value === 'string' && value.trim().length > 0) {
+        return value;
+      }
+    }
+  }
+
+  return error.message;
+}
+
+function normalizeHeaders(
+  headers: AxiosResponse['headers'],
+): Record<string, string> {
+  const normalized: Record<string, string> = {};
+
+  if (!headers) {
+    return normalized;
+  }
+
+  if (typeof (headers as AxiosResponse['headers'] & { forEach?: unknown }).forEach === 'function') {
+    const axiosHeaders = headers as AxiosResponse['headers'] & {
+      forEach: (callback: (value: string, key: string) => void) => void;
+    };
+    axiosHeaders.forEach((value, key) => {
+      normalized[key] = value;
+    });
+    return normalized;
+  }
+
+  Object.entries(headers as Record<string, unknown>).forEach(([key, value]) => {
+    if (Array.isArray(value)) {
+      normalized[key] = value.join(', ');
+      return;
+    }
+
+    if (typeof value === 'string') {
+      normalized[key] = value;
+      return;
+    }
+
+    if (value != null) {
+      normalized[key] = String(value);
+    }
+  });
+
+  return normalized;
+}
+
+function wait(delay: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delay);
+  });
+}
+
+async function applyRetry(
+  error: AxiosError,
+  config: HttpRequestConfig,
+): Promise<boolean> {
+  const policy: Required<RetryPolicy> = {
+    retries: config.retry?.retries ?? defaultRetryPolicy.retries,
+    retryDelay: config.retry?.retryDelay ?? defaultRetryPolicy.retryDelay,
+    retryCondition:
+      config.retry?.retryCondition ?? defaultRetryPolicy.retryCondition,
+  };
+
+  const currentRetryCount = config.__retryCount ?? 0;
+
+  if (currentRetryCount >= policy.retries) {
+    return false;
+  }
+
+  if (!policy.retryCondition(error)) {
+    return false;
+  }
+
+  const nextRetryCount = currentRetryCount + 1;
+  config.__retryCount = nextRetryCount;
+  const delay = Math.max(0, policy.retryDelay(nextRetryCount, error));
+  if (delay > 0) {
+    await wait(delay);
+  }
+
+  return true;
+}
+
+async function applyAuthenticationRetry(
+  error: AxiosError,
+  config: HttpRequestConfig,
+): Promise<boolean> {
+  if (config.skipAuth) {
+    return false;
+  }
+
+  if (config.__isAuthRetry) {
+    return false;
+  }
+
+  if (error.response?.status !== 401) {
+    return false;
+  }
+
+  if (!refreshTokenHandler) {
+    return false;
+  }
+
+  config.__isAuthRetry = true;
+
+  try {
+    if (!refreshPromise) {
+      refreshPromise = refreshTokenHandler(error).finally(() => {
+        refreshPromise = null;
+      });
+    }
+
+    const newToken = await refreshPromise;
+
+    if (!newToken) {
+      return false;
+    }
+
+    resolveAuthorizationHeader(newToken, config);
+    return true;
+  } catch (refreshError) {
+    console.warn('Refresh token handler failed', refreshError);
+    return false;
+  }
+}
+
+export function normalizeHttpError(error: unknown): HttpClientError {
+  if (error instanceof HttpClientError) {
+    return error;
+  }
+
+  if (axios.isAxiosError(error)) {
+    const axiosError = error as AxiosError;
+    const status = axiosError.response?.status;
+    const details = axiosError.response?.data;
+    const message = resolveErrorMessage(axiosError);
+    const timeoutCodes = new Set([
+      AxiosError.ECONNABORTED,
+      AxiosError.ETIMEDOUT,
+    ]);
+    const isTimeout =
+      typeof axiosError.code === 'string' && timeoutCodes.has(axiosError.code);
+    const isNetworkError =
+      !axiosError.response || axiosError.code === AxiosError.ERR_NETWORK;
+
+    return new HttpClientError({
+      status,
+      code: axiosError.code,
+      details,
+      message,
+      isNetworkError,
+      isTimeout,
+      isCanceled: axiosError.code === AxiosError.ERR_CANCELED,
+      originalError: axiosError,
+    });
+  }
+
+  const fallbackMessage =
+    error instanceof Error ? error.message : 'Erro inesperado na requisição';
+  return new HttpClientError({
+    message: fallbackMessage,
+    status: undefined,
+    code: undefined,
+    details: undefined,
+    isNetworkError: false,
+    isTimeout: false,
+    isCanceled: false,
+    originalError: error,
+  });
+}
+
+export function toHttpSuccessResponse<TData>(
+  response: AxiosResponse<TData>,
+): HttpSuccessResponse<TData> {
+  return {
+    data: response.data,
+    status: response.status,
+    headers: normalizeHeaders(response.headers),
+  };
+}
+
+export function setAccessTokenProvider(provider: AccessTokenProvider | null) {
+  accessTokenProvider = provider ?? (() => null);
+}
+
+export function setRefreshTokenHandler(
+  handler: RefreshTokenHandler | null,
+) {
+  refreshTokenHandler = handler;
+}
+
+export function setUnauthorizedHandler(
+  handler: UnauthorizedHandler | null,
+) {
+  unauthorizedHandler = handler;
+}
+
+export function setHttpErrorHandler(handler: HttpErrorHandler | null) {
+  httpErrorHandler = handler;
+}
+
+export function setDefaultRetryPolicy(policy: RetryPolicy) {
+  defaultRetryPolicy = {
+    retries: policy.retries ?? defaultRetryPolicy.retries,
+    retryDelay: policy.retryDelay ?? defaultRetryPolicy.retryDelay,
+    retryCondition:
+      policy.retryCondition ?? defaultRetryPolicy.retryCondition,
+  };
+}
+
+httpClient.interceptors.request.use(async (config) => {
+  const enrichedConfig = config as HttpRequestConfig & typeof config;
+
+  if (enrichedConfig.skipAuth) {
+    return config;
+  }
+
+  const token = await Promise.resolve(accessTokenProvider());
+  if (token) {
+    resolveAuthorizationHeader(token, enrichedConfig);
+  }
+
+  return config;
+});
+
+httpClient.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    if (!axios.isAxiosError(error) || !error.config) {
+      const normalized = normalizeHttpError(error);
+      httpErrorHandler?.(normalized);
+      return Promise.reject(normalized);
+    }
+
+    const enrichedConfig = error.config as HttpRequestConfig;
+
+    if (await applyAuthenticationRetry(error, enrichedConfig)) {
+      return httpClient(enrichedConfig);
+    }
+
+    if (await applyRetry(error, enrichedConfig)) {
+      return httpClient(enrichedConfig);
+    }
+
+    const normalized = normalizeHttpError(error);
+
+    if (normalized.status === 401) {
+      unauthorizedHandler?.(normalized);
+    }
+
+    httpErrorHandler?.(normalized);
+    return Promise.reject(normalized);
+  },
+);
+
+export default httpClient;

--- a/src/services/opportunitiesService.ts
+++ b/src/services/opportunitiesService.ts
@@ -1,0 +1,206 @@
+import httpClient, {
+  HttpClientError,
+  HttpRequestConfig,
+  HttpSuccessResponse,
+  normalizeHttpError,
+  toHttpSuccessResponse,
+} from './httpClient';
+
+export interface Opportunity {
+  id: string;
+  name: string;
+  stage: string;
+  region?: string;
+  createdAt: string;
+  updatedAt?: string;
+  valuation?: number;
+  probability?: number;
+  metadata?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface OpportunityFilters {
+  search?: string;
+  stage?: string;
+  region?: string;
+  ownerId?: string;
+  minValuation?: number;
+  maxValuation?: number;
+  limit?: number;
+  offset?: number;
+}
+
+export interface CreateOpportunityPayload {
+  name: string;
+  stage: string;
+  region?: string;
+  valuation?: number;
+  probability?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export type UpdateOpportunityPayload = Partial<CreateOpportunityPayload> & {
+  status?: string;
+  expectedCloseDate?: string;
+};
+
+export interface ServiceSuccess<TData> extends HttpSuccessResponse<TData> {
+  success: true;
+}
+
+export interface ServiceError {
+  success: false;
+  status?: number;
+  error: HttpClientError;
+}
+
+export type ServiceResult<TData> = ServiceSuccess<TData> | ServiceError;
+
+const BASE_PATH = '/opportunities';
+
+function toServiceSuccess<TData>(
+  response: HttpSuccessResponse<TData>,
+): ServiceSuccess<TData> {
+  return {
+    success: true,
+    ...response,
+  };
+}
+
+function toServiceError(error: unknown): ServiceError {
+  const normalized = normalizeHttpError(error);
+  return {
+    success: false,
+    status: normalized.status,
+    error: normalized,
+  };
+}
+
+function mergeParams(
+  base: HttpRequestConfig['params'],
+  extras: Record<string, unknown> | undefined,
+) {
+  if (!extras) {
+    return base;
+  }
+
+  return {
+    ...(typeof base === 'object' && base != null ? base : {}),
+    ...extras,
+  };
+}
+
+function toQueryFilters(filters?: OpportunityFilters) {
+  if (!filters) {
+    return undefined;
+  }
+
+  const entries = Object.entries(filters).filter(([, value]) => {
+    return value !== undefined && value !== null;
+  });
+
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  return Object.fromEntries(entries);
+}
+
+export async function listOpportunities(
+  filters?: OpportunityFilters,
+  config?: HttpRequestConfig,
+): Promise<ServiceResult<Opportunity[]>> {
+  try {
+    const requestConfig: HttpRequestConfig = {
+      ...config,
+      params: mergeParams(config?.params, toQueryFilters(filters)),
+    };
+
+    const response = await httpClient.get<Opportunity[]>(
+      BASE_PATH,
+      requestConfig,
+    );
+
+    return toServiceSuccess(toHttpSuccessResponse(response));
+  } catch (error) {
+    return toServiceError(error);
+  }
+}
+
+export async function getOpportunity(
+  id: string,
+  config?: HttpRequestConfig,
+): Promise<ServiceResult<Opportunity>> {
+  try {
+    const response = await httpClient.get<Opportunity>(
+      `${BASE_PATH}/${id}`,
+      config,
+    );
+
+    return toServiceSuccess(toHttpSuccessResponse(response));
+  } catch (error) {
+    return toServiceError(error);
+  }
+}
+
+export async function createOpportunity(
+  payload: CreateOpportunityPayload,
+  config?: HttpRequestConfig<CreateOpportunityPayload>,
+): Promise<ServiceResult<Opportunity>> {
+  try {
+    const response = await httpClient.post<Opportunity>(
+      BASE_PATH,
+      payload,
+      config,
+    );
+
+    return toServiceSuccess(toHttpSuccessResponse(response));
+  } catch (error) {
+    return toServiceError(error);
+  }
+}
+
+export async function updateOpportunity(
+  id: string,
+  payload: UpdateOpportunityPayload,
+  config?: HttpRequestConfig<UpdateOpportunityPayload>,
+): Promise<ServiceResult<Opportunity>> {
+  try {
+    const response = await httpClient.patch<Opportunity>(
+      `${BASE_PATH}/${id}`,
+      payload,
+      config,
+    );
+
+    return toServiceSuccess(toHttpSuccessResponse(response));
+  } catch (error) {
+    return toServiceError(error);
+  }
+}
+
+export async function deleteOpportunity(
+  id: string,
+  config?: HttpRequestConfig,
+): Promise<ServiceResult<null>> {
+  try {
+    const response = await httpClient.delete<null>(`${BASE_PATH}/${id}`, config);
+    return toServiceSuccess(toHttpSuccessResponse(response));
+  } catch (error) {
+    return toServiceError(error);
+  }
+}
+
+export function assertSuccess<TData>(
+  result: ServiceResult<TData>,
+): asserts result is ServiceSuccess<TData> {
+  if (!result.success) {
+    throw result.error;
+  }
+}
+
+export function unwrapResult<TData>(
+  result: ServiceResult<TData>,
+): TData {
+  assertSuccess(result);
+  return result.data;
+}

--- a/src/services/realtime.ts
+++ b/src/services/realtime.ts
@@ -1,0 +1,530 @@
+export type MaybeAsync<T> = T | Promise<T>;
+
+export type TokenProvider = string | (() => MaybeAsync<string | null>);
+
+export interface RealtimeOptions {
+  url?: string;
+  token?: TokenProvider;
+  protocols?: string | string[];
+  autoReconnect?: boolean;
+  maxReconnectAttempts?: number;
+  reconnectBackoff?: {
+    initialDelay?: number;
+    maxDelay?: number;
+    multiplier?: number;
+  };
+  onOpen?: (event: Event) => void;
+  onClose?: (event: CloseEvent) => void;
+  onError?: (event: Event) => void;
+}
+
+export interface RealtimeMessage<TPayload = unknown> {
+  channel: string;
+  event: string;
+  data: TPayload;
+  raw: MessageEvent;
+}
+
+export interface RealtimeAction<TPayload = unknown> {
+  type: string;
+  payload: RealtimeMessage<TPayload>;
+  meta?: Record<string, unknown>;
+}
+
+export type RealtimeDispatch = (action: RealtimeAction) => void;
+
+export type ChannelCallback<TPayload = unknown> = (
+  message: RealtimeMessage<TPayload>,
+) => void;
+
+interface Subscription {
+  callback: ChannelCallback;
+  events?: Set<string>;
+}
+
+interface InternalRealtimeOptions {
+  url?: string;
+  token?: TokenProvider;
+  protocols?: string | string[];
+  autoReconnect: boolean;
+  maxReconnectAttempts?: number;
+  reconnectBackoff: {
+    initialDelay: number;
+    maxDelay: number;
+    multiplier: number;
+  };
+  onOpen?: (event: Event) => void;
+  onClose?: (event: CloseEvent) => void;
+  onError?: (event: Event) => void;
+}
+
+const DEFAULT_BACKOFF = {
+  initialDelay: 1000,
+  maxDelay: 15000,
+  multiplier: 1.8,
+};
+
+const GLOBAL_CHANNEL = '*';
+
+const subscriptions = new Map<string, Set<Subscription>>();
+
+let activeSocket: WebSocket | null = null;
+let activeCleanup: (() => void) | null = null;
+let storedOptions: InternalRealtimeOptions | null = null;
+let originalOptions: RealtimeOptions | null = null;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let reconnectAttempts = 0;
+let manualDisconnect = false;
+let connectionPromise: Promise<WebSocket> | null = null;
+let realtimeDispatch: RealtimeDispatch | null = null;
+
+function getChannelKey(channel: string) {
+  return channel.toLowerCase();
+}
+
+function applyDefaults(options: RealtimeOptions): InternalRealtimeOptions {
+  return {
+    url: options.url,
+    token: options.token,
+    protocols: options.protocols,
+    autoReconnect: options.autoReconnect ?? true,
+    maxReconnectAttempts: options.maxReconnectAttempts,
+    reconnectBackoff: {
+      initialDelay:
+        options.reconnectBackoff?.initialDelay ?? DEFAULT_BACKOFF.initialDelay,
+      maxDelay: options.reconnectBackoff?.maxDelay ?? DEFAULT_BACKOFF.maxDelay,
+      multiplier:
+        options.reconnectBackoff?.multiplier ?? DEFAULT_BACKOFF.multiplier,
+    },
+    onOpen: options.onOpen,
+    onClose: options.onClose,
+    onError: options.onError,
+  };
+}
+
+function resolveRealtimeUrl(customUrl?: string): string {
+  if (customUrl) {
+    return customUrl;
+  }
+
+  const envUrl = import.meta.env?.VITE_REALTIME_URL;
+  if (envUrl) {
+    return envUrl;
+  }
+
+  if (typeof window !== 'undefined' && window.location) {
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    return `${protocol}//${window.location.host}/realtime`;
+  }
+
+  return 'ws://localhost:3001/realtime';
+}
+
+async function resolveToken(token?: TokenProvider): Promise<string | null> {
+  if (!token) {
+    return null;
+  }
+
+  if (typeof token === 'function') {
+    return token();
+  }
+
+  return token;
+}
+
+function appendTokenToUrl(url: string, token: string | null): string {
+  if (!token) {
+    return url;
+  }
+
+  try {
+    const base =
+      typeof window !== 'undefined' && window.location
+        ? window.location.href
+        : undefined;
+    const parsed = new URL(url, base);
+    parsed.searchParams.set('token', token);
+    return parsed.toString();
+  } catch (error) {
+    const separator = url.includes('?') ? '&' : '?';
+    return `${url}${separator}token=${encodeURIComponent(token)}`;
+  }
+}
+
+function notifySubscribers(message: RealtimeMessage) {
+  const channelKey = getChannelKey(message.channel);
+  const eventKey = message.event.toLowerCase();
+
+  const deliver = (key: string) => {
+    const bucket = subscriptions.get(key);
+    if (!bucket) {
+      return;
+    }
+
+    bucket.forEach((subscription) => {
+      if (!subscription.events || subscription.events.has(eventKey)) {
+        subscription.callback(message);
+      }
+    });
+  };
+
+  deliver(channelKey);
+  deliver(GLOBAL_CHANNEL);
+}
+
+function dispatchRealtime(message: RealtimeMessage) {
+  notifySubscribers(message);
+  realtimeDispatch?.({
+    type: 'realtime/message',
+    payload: message,
+    meta: {
+      channel: message.channel,
+      event: message.event,
+      receivedAt: Date.now(),
+    },
+  });
+}
+
+function parseRealtimeMessage(event: MessageEvent): RealtimeMessage {
+  const fallbackChannel = 'global';
+  const fallbackEvent = 'message';
+
+  let channel = fallbackChannel;
+  let eventName = fallbackEvent;
+  let data: unknown = event.data;
+
+  const assignFromRecord = (record: Record<string, unknown>) => {
+    if (typeof record.channel === 'string' && record.channel.trim()) {
+      channel = record.channel;
+    }
+
+    if (typeof record.event === 'string' && record.event.trim()) {
+      eventName = record.event;
+    } else if (typeof record.type === 'string' && record.type.trim()) {
+      eventName = record.type;
+    }
+
+    if ('payload' in record) {
+      data = record.payload;
+      return;
+    }
+
+    if ('data' in record) {
+      data = record.data;
+      return;
+    }
+
+    data = record;
+  };
+
+  if (typeof event.data === 'string') {
+    try {
+      const parsed = JSON.parse(event.data);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        assignFromRecord(parsed as Record<string, unknown>);
+      } else if (Array.isArray(parsed)) {
+        data = parsed;
+      } else {
+        data = parsed;
+      }
+    } catch (error) {
+      data = event.data;
+    }
+  } else if (
+    event.data &&
+    typeof event.data === 'object' &&
+    !Array.isArray(event.data)
+  ) {
+    assignFromRecord(event.data as Record<string, unknown>);
+  }
+
+  return {
+    channel,
+    event: eventName,
+    data,
+    raw: event,
+  };
+}
+
+function clearReconnectTimer() {
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+}
+
+function scheduleReconnect() {
+  if (!storedOptions || manualDisconnect) {
+    return;
+  }
+
+  const { maxReconnectAttempts, reconnectBackoff } = storedOptions;
+  if (
+    typeof maxReconnectAttempts === 'number' &&
+    reconnectAttempts >= maxReconnectAttempts
+  ) {
+    return;
+  }
+
+  const attempt = reconnectAttempts + 1;
+  const delay = Math.min(
+    reconnectBackoff.initialDelay *
+      Math.pow(reconnectBackoff.multiplier, attempt - 1),
+    reconnectBackoff.maxDelay,
+  );
+
+  reconnectTimer = setTimeout(() => {
+    connectRealtime(originalOptions ?? {}).catch(() => {
+      scheduleReconnect();
+    });
+  }, delay);
+
+  reconnectAttempts = attempt;
+}
+
+async function createSocket(
+  options: InternalRealtimeOptions,
+): Promise<WebSocket> {
+  return new Promise(async (resolve, reject) => {
+    try {
+      const token = await resolveToken(options.token);
+      const targetUrl = appendTokenToUrl(
+        resolveRealtimeUrl(options.url),
+        token,
+      );
+      const socket = new WebSocket(targetUrl, options.protocols);
+
+      if (activeCleanup) {
+        activeCleanup();
+        activeCleanup = null;
+      }
+
+      activeSocket = socket;
+
+      let settled = false;
+
+      const handleOpen = (event: Event) => {
+        reconnectAttempts = 0;
+        settled = true;
+        options.onOpen?.(event);
+        resolve(socket);
+      };
+
+      const handleMessage = (event: MessageEvent) => {
+        if (socket !== activeSocket) {
+          return;
+        }
+
+        dispatchRealtime(parseRealtimeMessage(event));
+      };
+
+      const handleClose = (event: CloseEvent) => {
+        if (socket === activeSocket) {
+          activeSocket = null;
+        }
+
+        options.onClose?.(event);
+
+        if (!settled) {
+          settled = true;
+          reject(
+            new Error(`Realtime connection closed before opening (code ${event.code})`),
+          );
+        }
+
+        cleanup();
+
+        if (!manualDisconnect && options.autoReconnect) {
+          scheduleReconnect();
+        }
+      };
+
+      const handleError = (event: Event) => {
+        options.onError?.(event);
+
+        if (!settled && socket.readyState !== WebSocket.OPEN) {
+          settled = true;
+          cleanup();
+          reject(new Error('Realtime connection error'));
+        }
+      };
+
+      const cleanup = () => {
+        socket.removeEventListener('open', handleOpen);
+        socket.removeEventListener('message', handleMessage);
+        socket.removeEventListener('close', handleClose);
+        socket.removeEventListener('error', handleError);
+
+        if (activeCleanup === cleanup) {
+          activeCleanup = null;
+        }
+      };
+
+      socket.addEventListener('open', handleOpen);
+      socket.addEventListener('message', handleMessage);
+      socket.addEventListener('close', handleClose);
+      socket.addEventListener('error', handleError);
+
+      activeCleanup = cleanup;
+    } catch (error) {
+      reject(error instanceof Error ? error : new Error(String(error)));
+    }
+  });
+}
+
+export async function connectRealtime(
+  options: RealtimeOptions = {},
+): Promise<WebSocket> {
+  manualDisconnect = false;
+  clearReconnectTimer();
+
+  if (
+    activeSocket &&
+    (activeSocket.readyState === WebSocket.OPEN ||
+      activeSocket.readyState === WebSocket.CONNECTING)
+  ) {
+    return activeSocket;
+  }
+
+  if (connectionPromise) {
+    return connectionPromise;
+  }
+
+  originalOptions = options;
+  storedOptions = applyDefaults(options);
+
+  connectionPromise = createSocket(storedOptions);
+
+  try {
+    return await connectionPromise;
+  } finally {
+    connectionPromise = null;
+  }
+}
+
+export function disconnectRealtime(code?: number, reason?: string) {
+  manualDisconnect = true;
+  clearReconnectTimer();
+  connectionPromise = null;
+
+  if (activeCleanup) {
+    activeCleanup();
+    activeCleanup = null;
+  }
+
+  const socket = activeSocket;
+  activeSocket = null;
+
+  if (!socket) {
+    return;
+  }
+
+  if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
+    socket.close(code ?? 1000, reason);
+  }
+}
+
+export function isRealtimeConnected() {
+  return activeSocket?.readyState === WebSocket.OPEN;
+}
+
+export function sendRealtimeMessage<TPayload>(
+  message: {
+    channel: string;
+    event?: string;
+    data?: TPayload;
+  },
+): boolean {
+  if (!activeSocket || activeSocket.readyState !== WebSocket.OPEN) {
+    return false;
+  }
+
+  const payload = {
+    channel: message.channel,
+    event: message.event ?? 'message',
+    data: message.data,
+  };
+
+  activeSocket.send(JSON.stringify(payload));
+  return true;
+}
+
+function registerSubscription(
+  channel: string,
+  subscription: Subscription,
+): () => void {
+  const key = getChannelKey(channel);
+  let bucket = subscriptions.get(key);
+
+  if (!bucket) {
+    bucket = new Set();
+    subscriptions.set(key, bucket);
+  }
+
+  bucket.add(subscription);
+
+  return () => {
+    bucket?.delete(subscription);
+    if (bucket && bucket.size === 0) {
+      subscriptions.delete(key);
+    }
+  };
+}
+
+function normalizeEventsFilter(events?: string | string[]) {
+  if (!events) {
+    return undefined;
+  }
+
+  const list = Array.isArray(events) ? events : [events];
+  return new Set(list.map((event) => event.toLowerCase()));
+}
+
+export function subscribeToChannel<TPayload>(
+  channel: string,
+  callback: ChannelCallback<TPayload>,
+  events?: string | string[],
+): () => void {
+  const subscription: Subscription = {
+    callback: callback as ChannelCallback,
+    events: normalizeEventsFilter(events),
+  };
+
+  return registerSubscription(channel, subscription);
+}
+
+export function subscribeToAlerts<TPayload>(
+  callback: ChannelCallback<TPayload>,
+  events?: string | string[],
+): () => void {
+  return subscribeToChannel('alerts', callback, events);
+}
+
+export function subscribeToEvents<TPayload>(
+  callback: ChannelCallback<TPayload>,
+  events?: string | string[],
+): () => void {
+  return subscribeToChannel('events', callback, events);
+}
+
+export function subscribeToAll<TPayload>(
+  callback: ChannelCallback<TPayload>,
+  events?: string | string[],
+): () => void {
+  return registerSubscription(GLOBAL_CHANNEL, {
+    callback: callback as ChannelCallback,
+    events: normalizeEventsFilter(events),
+  });
+}
+
+export function setRealtimeDispatch(dispatch: RealtimeDispatch | null) {
+  realtimeDispatch = dispatch;
+}
+
+export function getRealtimeSocket() {
+  return activeSocket;
+}
+
+export function getActiveSubscriptions() {
+  return Array.from(subscriptions.keys());
+}


### PR DESCRIPTION
## Summary
- configure a shared Axios client with authentication interceptors, retry policies, and unified error handling
- expose an opportunities service that wraps HTTP responses and normalizes failures for domain consumers
- add a realtime helper to manage websocket connections, dispatch updates, and subscribe to alert/event channels

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cdf86f36f48326ac6e35a3390bd4b7