### PR TITLE
Add Redux slices and React Query hooks for domain data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.vite/
+.DS_Store

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,56 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import tsParser from '@typescript-eslint/parser';
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+import reactRefresh from 'eslint-plugin-react-refresh';
+
+export default [
+  {
+    ignores: ['dist', 'node_modules'],
+  },
+  js.configs.recommended,
+  {
+    files: ['**/*.{ts,tsx,js,jsx}'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+      globals: {
+        ...globals.browser,
+        ...globals.es2021,
+        ...globals.node,
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+      'react-refresh': reactRefresh,
+    },
+    rules: {
+      ...tsPlugin.configs.recommended.rules,
+      ...reactRefresh.configs.recommended.rules,
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+    },
+  },
+  {
+    files: ['cypress/**/*.{ts,tsx,js,jsx}'],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.es2021,
+        ...globals.node,
+        ...globals.mocha,
+        ...globals.cypress,
+        cy: 'readonly',
+        Cypress: 'readonly',
+      },
+    },
+  },
+];

--- a/src/App.css
+++ b/src/App.css
@@ -27,3 +27,378 @@
   text-align: center;
   color: #0f172a;
 }
+
+.domain {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: clamp(1.5rem, 2vw, 2.5rem);
+  background: #f8fafc;
+  color: #0f172a;
+  min-height: 100%;
+}
+
+.domain__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 60rem;
+}
+
+.domain__nav {
+  border-bottom: 1px solid #cbd5f5;
+}
+
+.domain__nav-list {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  padding: 0;
+  margin: 0;
+}
+
+.domain__nav-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  text-decoration: none;
+  color: #1e293b;
+  background: #e2e8f0;
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  font-weight: 500;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.domain__nav-link:hover {
+  background: #cbd5f5;
+}
+
+.domain__nav-link--active {
+  background: #2563eb;
+  color: #fff;
+}
+
+.domain__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.domain__section {
+  background: #ffffff;
+  border-radius: 1rem;
+  padding: clamp(1.25rem, 2vw, 2rem);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.domain__section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.domain__section-header--with-controls {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+}
+
+.domain__section-caption {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #475569;
+}
+
+.domain__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.domain__metric {
+  background: #f1f5f9;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.domain__metric-title {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #475569;
+}
+
+.domain__metric-value {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.domain__metric-caption {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.domain__alert {
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  font-weight: 500;
+}
+
+.domain__alert--error {
+  background: #fee2e2;
+  color: #b91c1c;
+  border: 1px solid rgba(185, 28, 28, 0.2);
+}
+
+.domain__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.domain__toolbar-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-weight: 500;
+  color: #1f2937;
+}
+
+.domain__toolbar-select {
+  appearance: none;
+  border: 1px solid #cbd5f5;
+  background: #fff;
+  border-radius: 0.5rem;
+  padding: 0.45rem 0.75rem;
+  font-size: 0.95rem;
+  min-width: 8rem;
+}
+
+.domain__toolbar-action {
+  border: 1px solid #2563eb;
+  background: transparent;
+  color: #2563eb;
+  border-radius: 9999px;
+  padding: 0.45rem 1rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.domain__toolbar-action:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.domain__form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.domain__form-fieldset {
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 1rem;
+}
+
+.domain__form-legend {
+  padding: 0 0.5rem;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.domain__form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.domain__form-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.9rem;
+  color: #334155;
+}
+
+.domain__form-input {
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid #cbd5f5;
+  font-size: 0.95rem;
+}
+
+.domain__form-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 1rem;
+}
+
+.domain__button {
+  border: none;
+  background: #2563eb;
+  color: #fff;
+  border-radius: 0.65rem;
+  padding: 0.55rem 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.domain__button:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
+.domain__button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.domain__button--secondary {
+  background: #0f172a;
+}
+
+.domain__button--danger {
+  background: #dc2626;
+}
+
+.domain__table-wrapper {
+  overflow-x: auto;
+}
+
+.domain__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.domain__table th,
+.domain__table td {
+  padding: 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.domain__table thead tr {
+  background: #f1f5f9;
+}
+
+.domain__table-row--optimistic {
+  opacity: 0.65;
+}
+
+.domain__table-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.domain__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.domain__list--columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+}
+
+.domain__list-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.domain__list-label {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.domain__list-value {
+  font-variant-numeric: tabular-nums;
+  color: #0f172a;
+}
+
+.domain__list-description {
+  margin: 0.25rem 0 0;
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.domain__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: #e2e8f0;
+  color: #1f2937;
+  border-radius: 9999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.domain__badge--positive {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.domain__badge--negative {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.domain__badge--neutral {
+  background: #e0e7ff;
+  color: #3730a3;
+}
+
+.domain__status {
+  margin: 0;
+  color: #334155;
+}
+
+.domain__panel {
+  background: #f8fafc;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.domain__panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.domain__panel-status {
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.domain__panels {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}

--- a/src/domains/analise/index.tsx
+++ b/src/domains/analise/index.tsx
@@ -1,4 +1,19 @@
+import { ChangeEvent } from 'react';
 import { NavLink, Outlet, Route, Routes } from 'react-router-dom';
+
+import {
+  useDashboardSummaryQuery,
+  useInvalidateDashboardSummary,
+} from '@/hooks/useDashboardQueries';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
+import {
+  selectDashboardError,
+  selectDashboardStatus,
+  selectDashboardSummary,
+  selectDashboardTimeframe,
+  setDashboardTimeframe,
+} from '@/store/dashboardsSlice';
+import type { DashboardTimeframe } from '@/services/dashboardService';
 
 type NavigationLink = {
   readonly label: string;
@@ -11,6 +26,17 @@ const LINKS: NavigationLink[] = [
   { label: 'Modelagem de valuation', to: 'modelagem' },
   { label: 'Cenários e sensibilidade', to: 'cenarios' },
 ];
+
+const percentFormatter = new Intl.NumberFormat('pt-BR', {
+  style: 'percent',
+  maximumFractionDigits: 1,
+});
+
+const currencyFormatter = new Intl.NumberFormat('pt-BR', {
+  style: 'currency',
+  currency: 'BRL',
+  maximumFractionDigits: 0,
+});
 
 function AnalysisLayout() {
   return (
@@ -51,37 +77,177 @@ function AnalysisLayout() {
 }
 
 function AnalysisOverview() {
+  const dispatch = useAppDispatch();
+  const timeframe = useAppSelector((state) =>
+    selectDashboardTimeframe(state, 'analysis'),
+  );
+  const summary = useAppSelector((state) =>
+    selectDashboardSummary(state, 'analysis'),
+  );
+  const status = useAppSelector((state) =>
+    selectDashboardStatus(state, 'analysis'),
+  );
+  const error = useAppSelector((state) =>
+    selectDashboardError(state, 'analysis'),
+  );
+  const invalidate = useInvalidateDashboardSummary('analysis');
+  const query = useDashboardSummaryQuery('analysis', { timeframe });
+  const metrics = summary?.metrics ?? [];
+
+  const handleTimeframeChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value as DashboardTimeframe;
+    dispatch(setDashboardTimeframe({ scope: 'analysis', timeframe: value }));
+    invalidate(value);
+  };
+
   return (
     <article className="domain__section">
-      <h2>Indicadores de análise</h2>
-      <p>
-        Consulte rapidamente fluxo de caixa descontado, cap rates e métricas de
-        risco para cada ativo em avaliação.
-      </p>
+      <header className="domain__section-header domain__section-header--with-controls">
+        <div>
+          <h2>Indicadores de análise</h2>
+          <p className="domain__section-caption">
+            Fluxo de caixa descontado, cap rates e métricas de risco atuais.
+          </p>
+        </div>
+        <label className="domain__toolbar-label" htmlFor="analysis-timeframe">
+          Janela de tempo
+          <select
+            id="analysis-timeframe"
+            className="domain__toolbar-select"
+            value={timeframe}
+            onChange={handleTimeframeChange}
+          >
+            <option value="7d">7 dias</option>
+            <option value="30d">30 dias</option>
+            <option value="90d">90 dias</option>
+            <option value="180d">180 dias</option>
+          </select>
+        </label>
+      </header>
+
+      {status === 'failed' && error ? (
+        <div className="domain__alert domain__alert--error" role="alert">
+          {error}
+        </div>
+      ) : null}
+
+      {query.isFetching ? (
+        <p className="domain__status">Recalculando métricas…</p>
+      ) : null}
+
+      {summary ? (
+        <div className="domain__metrics">
+          {metrics.map((metric) => (
+            <div key={metric.id} className="domain__metric">
+              <dt className="domain__metric-title">{metric.label}</dt>
+              <dd className="domain__metric-value">
+                {metric.unit === 'percent'
+                  ? percentFormatter.format(metric.value / 100)
+                  : currencyFormatter.format(metric.value)}
+              </dd>
+              {metric.description ? (
+                <dd className="domain__metric-caption">{metric.description}</dd>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p>Nenhum indicador disponível para o período selecionado.</p>
+      )}
     </article>
   );
 }
 
 function AnalysisValuation() {
+  const summary = useAppSelector((state) =>
+    selectDashboardSummary(state, 'analysis'),
+  );
+  const breakdowns = summary?.breakdowns ?? [];
+
   return (
     <article className="domain__section">
-      <h2>Modelagem de valuation</h2>
-      <p>
-        Configure parâmetros, taxas e premissas de saída para projetar cenários
-        otimizados de retorno financeiro e validar o preço-alvo de aquisição.
-      </p>
+      <header className="domain__section-header">
+        <h2>Modelagem de valuation</h2>
+        <p className="domain__section-caption">
+          Ajuste premissas de retorno e compare ativos lado a lado.
+        </p>
+      </header>
+
+      {summary ? (
+        <div className="domain__table-wrapper">
+          <table className="domain__table">
+            <thead>
+              <tr>
+                <th>Ativo</th>
+                <th>Cap rate</th>
+                <th>Valuation base</th>
+                <th>Sensibilidade</th>
+              </tr>
+            </thead>
+            <tbody>
+              {breakdowns.map((item) => (
+                <tr key={item.id}>
+                  <td>{item.label}</td>
+                  <td>{percentFormatter.format((item.percentage ?? 0) / 100)}</td>
+                  <td>{currencyFormatter.format(item.value)}</td>
+                  <td>
+                    {item.percentage != null
+                      ? percentFormatter.format(item.percentage / 100)
+                      : '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p>Selecione um período na visão geral para carregar os dados.</p>
+      )}
     </article>
   );
 }
 
 function AnalysisScenarios() {
+  const summary = useAppSelector((state) =>
+    selectDashboardSummary(state, 'analysis'),
+  );
+  const highlights = summary?.highlights ?? [];
+
   return (
     <article className="domain__section">
-      <h2>Cenários e sensibilidade</h2>
-      <p>
-        Simule choques de mercado, alterações de vacância e custos operacionais
-        para entender o impacto nas métricas principais de desempenho.
-      </p>
+      <header className="domain__section-header">
+        <h2>Cenários e sensibilidade</h2>
+        <p className="domain__section-caption">
+          Avalie impactos de choques macroeconômicos e revise hipóteses.
+        </p>
+      </header>
+
+      {summary ? (
+        <ul className="domain__list">
+          {highlights.length === 0 ? (
+            <li>Nenhum cenário crítico identificado.</li>
+          ) : (
+            highlights.map((highlight) => (
+              <li key={highlight.id} className="domain__list-item">
+                <div>
+                  <strong>{highlight.title}</strong>
+                  <p className="domain__list-description">
+                    {highlight.description}
+                  </p>
+                </div>
+                {highlight.probability != null ? (
+                  <span className="domain__badge domain__badge--neutral">
+                    Probabilidade:{' '}
+                    {percentFormatter.format(highlight.probability / 100)}
+                  </span>
+                ) : null}
+              </li>
+            ))
+          )}
+        </ul>
+      ) : (
+        <p>Não há simulações registradas para o período selecionado.</p>
+      )}
     </article>
   );
 }

--- a/src/domains/originacao/index.tsx
+++ b/src/domains/originacao/index.tsx
@@ -1,4 +1,29 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { NavLink, Outlet, Route, Routes } from 'react-router-dom';
+
+import {
+  useCreateOpportunityMutation,
+  useDeleteOpportunityMutation,
+  usePipelineQuery,
+  useUpdateOpportunityMutation,
+} from '@/hooks/useOpportunityQueries';
+import { useDashboardSummaryQuery } from '@/hooks/useDashboardQueries';
+import { useAppSelector } from '@/store/hooks';
+import {
+  selectAllPipelineOpportunities,
+  selectPipelineByStage,
+  selectPipelineError,
+  selectPipelineLastUpdatedAt,
+  selectPipelineOptimisticIds,
+  selectPipelineStatus,
+  selectPipelineTotals,
+} from '@/store/pipelineSlice';
+import {
+  selectDashboardError,
+  selectDashboardStatus,
+  selectDashboardSummary,
+} from '@/store/dashboardsSlice';
+import { selectActivePortfolioId } from '@/store/portfolioSlice';
 
 type NavigationLink = {
   readonly label: string;
@@ -11,6 +36,19 @@ const LINKS: NavigationLink[] = [
   { label: 'Pipeline de negócios', to: 'pipeline' },
   { label: 'Relatórios e indicadores', to: 'relatorios' },
 ];
+
+const currencyFormatter = new Intl.NumberFormat('pt-BR', {
+  style: 'currency',
+  currency: 'BRL',
+  maximumFractionDigits: 0,
+});
+
+const percentFormatter = new Intl.NumberFormat('pt-BR', {
+  style: 'percent',
+  maximumFractionDigits: 0,
+});
+
+const dateFormatter = new Intl.DateTimeFormat('pt-BR');
 
 function OriginationLayout() {
   return (
@@ -51,38 +89,476 @@ function OriginationLayout() {
 }
 
 function OriginationOverview() {
+  const query = usePipelineQuery();
+  const status = useAppSelector(selectPipelineStatus);
+  const error = useAppSelector(selectPipelineError);
+  const totals = useAppSelector(selectPipelineTotals);
+  const opportunities = useAppSelector(selectAllPipelineOpportunities);
+  const lastUpdatedAt = useAppSelector(selectPipelineLastUpdatedAt);
+
+  const stageDistribution = useMemo(() => {
+    const distribution = new Map<string, number>();
+    opportunities.forEach((opportunity) => {
+      const stage = opportunity.stage ?? 'Sem estágio';
+      distribution.set(stage, (distribution.get(stage) ?? 0) + 1);
+    });
+
+    return Array.from(distribution.entries()).sort((a, b) => b[1] - a[1]);
+  }, [opportunities]);
+
   return (
     <article className="domain__section">
-      <h2>Resumo das captações</h2>
-      <p>
-        Visualize os indicadores críticos da originação, como volume captado
-        por região, taxa de conversão por etapa e oportunidades com prioridade
-        máxima.
-      </p>
+      <header className="domain__section-header">
+        <h2>Resumo das captações</h2>
+        {lastUpdatedAt ? (
+          <span className="domain__section-caption">
+            Atualizado em {dateFormatter.format(lastUpdatedAt)}
+          </span>
+        ) : null}
+      </header>
+
+      {status === 'failed' && error ? (
+        <div className="domain__alert domain__alert--error" role="alert">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="domain__metrics" aria-live="polite">
+        <div className="domain__metric">
+          <dt className="domain__metric-title">Volume em análise</dt>
+          <dd className="domain__metric-value">
+            {currencyFormatter.format(totals.totalValuation ?? 0)}
+          </dd>
+          <dd className="domain__metric-caption">
+            Soma do valuation das oportunidades no funil
+          </dd>
+        </div>
+        <div className="domain__metric">
+          <dt className="domain__metric-title">Oportunidades</dt>
+          <dd className="domain__metric-value">{totals.totalCount}</dd>
+          <dd className="domain__metric-caption">
+            Itens ativos em prospecção e negociação
+          </dd>
+        </div>
+        <div className="domain__metric">
+          <dt className="domain__metric-title">Probabilidade média</dt>
+          <dd className="domain__metric-value">
+            {percentFormatter.format((totals.averageProbability ?? 0) / 100)}
+          </dd>
+          <dd className="domain__metric-caption">
+            Probabilidade ponderada das oportunidades em carteira
+          </dd>
+        </div>
+      </div>
+
+      <section className="domain__panel">
+        <header className="domain__panel-header">
+          <h3>Distribuição por estágio</h3>
+          {query.isFetching ? (
+            <span className="domain__panel-status" aria-live="polite">
+              Atualizando…
+            </span>
+          ) : null}
+        </header>
+        <ul className="domain__list domain__list--columns">
+          {stageDistribution.length === 0 ? (
+            <li>Nenhuma oportunidade cadastrada até o momento.</li>
+          ) : (
+            stageDistribution.map(([stage, count]) => (
+              <li key={stage} className="domain__list-item">
+                <span className="domain__list-label">{stage}</span>
+                <span className="domain__list-value">{count}</span>
+              </li>
+            ))
+          )}
+        </ul>
+      </section>
     </article>
   );
 }
 
 function OriginationPipeline() {
+  const [stageFilter, setStageFilter] = useState<string>('');
+  const [name, setName] = useState('');
+  const [stage, setStage] = useState('Lead');
+  const [valuation, setValuation] = useState('');
+  const [probability, setProbability] = useState('40');
+  const createOpportunity = useCreateOpportunityMutation();
+  const updateOpportunity = useUpdateOpportunityMutation();
+  const deleteOpportunity = useDeleteOpportunityMutation();
+  const filters = stageFilter ? { stage: stageFilter } : undefined;
+  const query = usePipelineQuery(filters);
+  const opportunities = useAppSelector((state) =>
+    selectPipelineByStage(state, stageFilter || null),
+  );
+  const allOpportunities = useAppSelector(selectAllPipelineOpportunities);
+  const optimisticIds = useAppSelector(selectPipelineOptimisticIds);
+  const error = useAppSelector(selectPipelineError);
+  const status = useAppSelector(selectPipelineStatus);
+
+  const stageOptions = useMemo(() => {
+    const stages = new Set<string>();
+    allOpportunities.forEach((opportunity) => {
+      if (opportunity.stage) {
+        stages.add(opportunity.stage);
+      }
+    });
+
+    return Array.from(stages.values()).sort((a, b) => a.localeCompare(b));
+  }, [allOpportunities]);
+
+  useEffect(() => {
+    if (stageOptions.length === 0) {
+      setStage('Lead');
+      return;
+    }
+
+    if (!stageOptions.includes(stage)) {
+      setStage(stageOptions[0]);
+    }
+  }, [stage, stageOptions]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!name.trim()) {
+      return;
+    }
+
+    const payload = {
+      name: name.trim(),
+      stage: stage || stageOptions[0] ?? 'Lead',
+      valuation: valuation ? Number(valuation) : undefined,
+      probability: probability ? Number(probability) : undefined,
+    };
+
+    createOpportunity.mutate(payload, {
+      onSuccess: () => {
+        setName('');
+        setStage(stageOptions[0] ?? '');
+        setValuation('');
+        setProbability('40');
+      },
+    });
+  };
+
+  const handleIncreaseProbability = (id: string, current: number | undefined) => {
+    const next = Math.min(100, (current ?? 0) + 10);
+    updateOpportunity.mutate({ id, payload: { probability: next } });
+  };
+
+  const handleDelete = (id: string) => {
+    deleteOpportunity.mutate(id);
+  };
+
   return (
     <article className="domain__section">
-      <h2>Pipeline de negócios</h2>
-      <p>
-        Consolide oportunidades por estágio, identifique gargalos e acompanhe
-        responsáveis com atraso para garantir a fluidez do funil.
-      </p>
+      <header className="domain__section-header">
+        <h2>Pipeline de negócios</h2>
+        <div className="domain__toolbar">
+          <label htmlFor="stage-filter" className="domain__toolbar-label">
+            Estágio
+          </label>
+          <select
+            id="stage-filter"
+            className="domain__toolbar-select"
+            value={stageFilter}
+            onChange={(event) => setStageFilter(event.target.value)}
+          >
+            <option value="">Todos</option>
+            {stageOptions.map((stage) => (
+              <option key={stage} value={stage}>
+                {stage}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            className="domain__toolbar-action"
+            onClick={() => query.refetch()}
+            disabled={query.isFetching}
+          >
+            {query.isFetching ? 'Atualizando…' : 'Recarregar'}
+          </button>
+        </div>
+      </header>
+
+      {error && status === 'failed' ? (
+        <div className="domain__alert domain__alert--error" role="alert">
+          {error}
+        </div>
+      ) : null}
+
+      <form className="domain__form" onSubmit={handleSubmit}>
+        <fieldset className="domain__form-fieldset">
+          <legend className="domain__form-legend">
+            Nova oportunidade
+          </legend>
+          <div className="domain__form-grid">
+            <label className="domain__form-label">
+              Nome
+              <input
+                className="domain__form-input"
+                name="name"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="Ex.: Torre Atlântica"
+                required
+              />
+            </label>
+            <label className="domain__form-label">
+              Estágio
+              <select
+                className="domain__form-input"
+                name="stage"
+                value={stage}
+                onChange={(event) => setStage(event.target.value)}
+              >
+                {stageOptions.length === 0 ? (
+                  <option value="Lead">Lead</option>
+                ) : (
+                  stageOptions.map((option) => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))
+                )}
+              </select>
+            </label>
+            <label className="domain__form-label">
+              Valuation (R$)
+              <input
+                className="domain__form-input"
+                name="valuation"
+                type="number"
+                min="0"
+                step="10000"
+                value={valuation}
+                onChange={(event) => setValuation(event.target.value)}
+              />
+            </label>
+            <label className="domain__form-label">
+              Probabilidade (%)
+              <input
+                className="domain__form-input"
+                name="probability"
+                type="number"
+                min="0"
+                max="100"
+                step="5"
+                value={probability}
+                onChange={(event) => setProbability(event.target.value)}
+              />
+            </label>
+          </div>
+          <div className="domain__form-actions">
+            <button
+              type="submit"
+              className="domain__button"
+              disabled={createOpportunity.isPending}
+            >
+              {createOpportunity.isPending
+                ? 'Salvando…'
+                : 'Adicionar oportunidade'}
+            </button>
+          </div>
+        </fieldset>
+      </form>
+
+      <div className="domain__table-wrapper">
+        <table className="domain__table">
+          <thead>
+            <tr>
+              <th>Nome</th>
+              <th>Estágio</th>
+              <th>Valuation</th>
+              <th>Probabilidade</th>
+              <th>Atualização</th>
+              <th aria-label="Ações" />
+            </tr>
+          </thead>
+          <tbody>
+            {query.isLoading && opportunities.length === 0 ? (
+              <tr>
+                <td colSpan={6}>Carregando pipeline…</td>
+              </tr>
+            ) : null}
+            {opportunities.length === 0 && !query.isLoading ? (
+              <tr>
+                <td colSpan={6}>Nenhuma oportunidade encontrada.</td>
+              </tr>
+            ) : null}
+            {opportunities.map((opportunity) => {
+              const isOptimistic = optimisticIds.includes(opportunity.id);
+              return (
+                <tr
+                  key={opportunity.id}
+                  data-optimistic={isOptimistic ? 'true' : undefined}
+                  className={
+                    isOptimistic ? 'domain__table-row domain__table-row--optimistic' : 'domain__table-row'
+                  }
+                >
+                  <td>{opportunity.name}</td>
+                  <td>{opportunity.stage ?? 'Sem estágio'}</td>
+                  <td>
+                    {opportunity.valuation != null
+                      ? currencyFormatter.format(Number(opportunity.valuation))
+                      : '—'}
+                  </td>
+                  <td>
+                    {opportunity.probability != null
+                      ? percentFormatter.format(Number(opportunity.probability) / 100)
+                      : '—'}
+                  </td>
+                  <td>
+                    {opportunity.updatedAt
+                      ? dateFormatter.format(new Date(opportunity.updatedAt))
+                      : dateFormatter.format(new Date(opportunity.createdAt))}
+                  </td>
+                  <td className="domain__table-actions">
+                    <button
+                      type="button"
+                      className="domain__button domain__button--secondary"
+                      onClick={() =>
+                        handleIncreaseProbability(
+                          opportunity.id,
+                          opportunity.probability,
+                        )
+                      }
+                      disabled={updateOpportunity.isPending}
+                    >
+                      Aumentar chance
+                    </button>
+                    <button
+                      type="button"
+                      className="domain__button domain__button--danger"
+                      onClick={() => handleDelete(opportunity.id)}
+                      disabled={deleteOpportunity.isPending}
+                    >
+                      Remover
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
     </article>
   );
 }
 
 function OriginationReports() {
+  const activePortfolioId = useAppSelector(selectActivePortfolioId);
+  const query = useDashboardSummaryQuery('origination', {
+    filters: activePortfolioId ? { portfolioId: activePortfolioId } : undefined,
+  });
+  const summary = useAppSelector((state) =>
+    selectDashboardSummary(state, 'origination'),
+  );
+  const status = useAppSelector((state) =>
+    selectDashboardStatus(state, 'origination'),
+  );
+  const error = useAppSelector((state) =>
+    selectDashboardError(state, 'origination'),
+  );
+  const metrics = summary?.metrics ?? [];
+  const breakdowns = summary?.breakdowns ?? [];
+  const highlights = summary?.highlights ?? [];
+
   return (
     <article className="domain__section">
-      <h2>Relatórios e indicadores</h2>
-      <p>
-        Gere relatórios personalizáveis com métricas de originação, taxas de
-        sucesso e performance comparativa entre períodos.
-      </p>
+      <header className="domain__section-header">
+        <h2>Relatórios e indicadores</h2>
+        {summary?.updatedAt ? (
+          <span className="domain__section-caption">
+            Atualizado em {dateFormatter.format(new Date(summary.updatedAt))}
+          </span>
+        ) : null}
+      </header>
+
+      {status === 'failed' && error ? (
+        <div className="domain__alert domain__alert--error" role="alert">
+          {error}
+        </div>
+      ) : null}
+
+      {query.isFetching ? (
+        <p className="domain__status">Sincronizando indicadores…</p>
+      ) : null}
+
+      {summary ? (
+        <div className="domain__panels">
+          <section className="domain__panel">
+            <h3>Métricas principais</h3>
+            <ul className="domain__list">
+              {metrics.map((metric) => (
+                <li key={metric.id} className="domain__list-item">
+                  <span className="domain__list-label">{metric.label}</span>
+                  <span className="domain__list-value">
+                    {metric.unit === 'percent'
+                      ? percentFormatter.format(metric.value / 100)
+                      : currencyFormatter.format(metric.value)}
+                  </span>
+                  {metric.change != null ? (
+                    <span
+                      className={
+                        metric.change >= 0
+                          ? 'domain__badge domain__badge--positive'
+                          : 'domain__badge domain__badge--negative'
+                      }
+                    >
+                      {metric.change >= 0 ? '+' : ''}
+                      {percentFormatter.format(metric.change / 100)}
+                    </span>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="domain__panel">
+            <h3>Distribuição por região</h3>
+            <ul className="domain__list domain__list--columns">
+              {breakdowns.map((item) => (
+                <li key={item.id} className="domain__list-item">
+                  <span className="domain__list-label">{item.label}</span>
+                  <span className="domain__list-value">
+                    {percentFormatter.format((item.percentage ?? 0) / 100)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="domain__panel">
+            <h3>Alertas de análise</h3>
+            <ul className="domain__list">
+              {highlights.length === 0 ? (
+                <li>Nenhum alerta no momento.</li>
+              ) : (
+                highlights.map((highlight) => (
+                  <li key={highlight.id} className="domain__list-item">
+                    <div>
+                      <strong>{highlight.title}</strong>
+                      <p className="domain__list-description">
+                        {highlight.description}
+                      </p>
+                    </div>
+                    {highlight.impact != null ? (
+                      <span className="domain__badge">
+                        Impacto:{' '}
+                        {percentFormatter.format(highlight.impact / 100)}
+                      </span>
+                    ) : null}
+                  </li>
+                ))
+              )}
+            </ul>
+          </section>
+        </div>
+      ) : (
+        <p>Nenhum relatório disponível até o momento.</p>
+      )}
     </article>
   );
 }

--- a/src/hooks/useDashboardQueries.ts
+++ b/src/hooks/useDashboardQueries.ts
@@ -1,0 +1,129 @@
+import { useEffect } from 'react';
+import { useQuery, useQueryClient, type QueryKey } from '@tanstack/react-query';
+
+import {
+  assertDashboardSuccess,
+  fetchDashboardSummary,
+  type DashboardFilters,
+  type DashboardTimeframe,
+} from '@/services/dashboardService';
+import {
+  selectDashboardTimeframe,
+  setDashboardError,
+  setDashboardStatus,
+  setDashboardSummary,
+  setDashboardTimeframe,
+} from '@/store/dashboardsSlice';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
+import { getErrorMessage } from '@/utils/errors';
+
+const DASHBOARD_QUERY_KEY = ['dashboards'] as const;
+
+type DashboardQueryKey = readonly [
+  typeof DASHBOARD_QUERY_KEY[0],
+  string,
+  DashboardTimeframe,
+  ...unknown[],
+];
+
+function normalizeFilters(filters?: DashboardFilters | null) {
+  if (!filters) {
+    return null;
+  }
+
+  const entries = Object.entries(filters).filter(([, value]) =>
+    value !== undefined && value !== null && value !== '',
+  );
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return Object.fromEntries(entries) as DashboardFilters;
+}
+
+export function getDashboardQueryKey(
+  scope: string,
+  timeframe: DashboardTimeframe,
+  filters?: DashboardFilters | null,
+): DashboardQueryKey {
+  const normalized = normalizeFilters(filters);
+  if (!normalized) {
+    return [...DASHBOARD_QUERY_KEY, scope, timeframe];
+  }
+
+  return [...DASHBOARD_QUERY_KEY, scope, timeframe, normalized];
+}
+
+export function useDashboardSummaryQuery(
+  scope: string,
+  options?: {
+    timeframe?: DashboardTimeframe;
+    filters?: DashboardFilters;
+    enabled?: boolean;
+  },
+) {
+  const dispatch = useAppDispatch();
+  const storedTimeframe = useAppSelector((state) =>
+    selectDashboardTimeframe(state, scope),
+  );
+  const activeTimeframe = options?.timeframe ?? storedTimeframe;
+  const filters = options?.filters;
+  const queryKey = getDashboardQueryKey(scope, activeTimeframe, filters ?? null);
+
+  useEffect(() => {
+    if (options?.timeframe) {
+      dispatch(setDashboardTimeframe({ scope, timeframe: options.timeframe }));
+      return;
+    }
+
+    if (!storedTimeframe) {
+      dispatch(setDashboardTimeframe({ scope, timeframe: activeTimeframe }));
+    }
+  }, [dispatch, scope, options?.timeframe, storedTimeframe, activeTimeframe]);
+
+  return useQuery({
+    queryKey,
+    enabled: options?.enabled ?? true,
+    queryFn: async () => {
+      dispatch(setDashboardStatus({ scope, status: 'loading' }));
+      const result = await fetchDashboardSummary({
+        scope,
+        timeframe: activeTimeframe,
+        ...filters,
+      });
+      assertDashboardSuccess(result);
+      return result.data;
+    },
+    staleTime: 60_000,
+    onSuccess: (data) => {
+      dispatch(setDashboardSummary({ scope, summary: data }));
+      dispatch(setDashboardStatus({ scope, status: 'succeeded' }));
+      dispatch(setDashboardError({ scope, error: null }));
+    },
+    onError: (error) => {
+      dispatch(setDashboardStatus({ scope, status: 'failed' }));
+      dispatch(
+        setDashboardError({
+          scope,
+          error: getErrorMessage(
+            error,
+            'Não foi possível carregar os indicadores.',
+          ),
+        }),
+      );
+    },
+  });
+}
+
+export function useInvalidateDashboardSummary(scope: string) {
+  const queryClient = useQueryClient();
+  return (timeframe?: DashboardTimeframe) => {
+    const partialKey: QueryKey = timeframe
+      ? [DASHBOARD_QUERY_KEY[0], scope, timeframe]
+      : [DASHBOARD_QUERY_KEY[0], scope];
+    return queryClient.invalidateQueries({ queryKey: partialKey });
+  };
+}
+
+export { DASHBOARD_QUERY_KEY };

--- a/src/hooks/useOpportunityQueries.ts
+++ b/src/hooks/useOpportunityQueries.ts
@@ -1,0 +1,393 @@
+import { useEffect } from 'react';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type QueryClient,
+  type QueryKey,
+} from '@tanstack/react-query';
+
+import {
+  assertSuccess,
+  createOpportunity,
+  deleteOpportunity,
+  listOpportunities,
+  type CreateOpportunityPayload,
+  type Opportunity,
+  type OpportunityFilters,
+  type UpdateOpportunityPayload,
+  updateOpportunity,
+} from '@/services/opportunitiesService';
+import {
+  clearPipelineOptimistic,
+  markPipelineOptimistic,
+  removePipelineOpportunity,
+  replacePipeline,
+  selectPipelineFilters,
+  setPipelineError,
+  setPipelineFilters,
+  setPipelineLastUpdatedAt,
+  setPipelineStatus,
+  upsertPipelineOpportunity,
+} from '@/store/pipelineSlice';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
+import { getErrorMessage } from '@/utils/errors';
+
+const PIPELINE_QUERY_KEY = ['pipeline'] as const;
+
+type PipelineQueryKey = readonly [typeof PIPELINE_QUERY_KEY[0], ...unknown[]];
+
+type PipelineQueryContext = {
+  previousQueries: Array<[QueryKey, Opportunity[] | undefined]>;
+  optimisticOpportunity?: Opportunity;
+};
+
+function getGlobalCrypto(): Crypto | undefined {
+  if (typeof globalThis === 'undefined') {
+    return undefined;
+  }
+
+  return globalThis.crypto as Crypto | undefined;
+}
+
+function generateOptimisticId() {
+  const cryptoInstance = getGlobalCrypto();
+  if (cryptoInstance && typeof cryptoInstance.randomUUID === 'function') {
+    return cryptoInstance.randomUUID();
+  }
+
+  return `optimistic-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function normalizeFilters(filters?: OpportunityFilters | null) {
+  if (!filters) {
+    return null;
+  }
+
+  const entries = Object.entries(filters).filter(([, value]) =>
+    value !== undefined && value !== null && value !== '',
+  );
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return Object.fromEntries(entries) as OpportunityFilters;
+}
+
+export function getPipelineQueryKey(
+  filters?: OpportunityFilters | null,
+): PipelineQueryKey {
+  const normalized = normalizeFilters(filters);
+  if (!normalized) {
+    return [...PIPELINE_QUERY_KEY, 'all'];
+  }
+
+  return [...PIPELINE_QUERY_KEY, normalized];
+}
+
+function applyToAllPipelineQueries(
+  queryClient: QueryClient,
+  updater: (data: Opportunity[] | undefined) => Opportunity[] | undefined,
+) {
+  const queries = queryClient.getQueriesData<Opportunity[]>({
+    queryKey: PIPELINE_QUERY_KEY,
+  });
+
+  queries.forEach(([key]) => {
+    queryClient.setQueryData<Opportunity[]>(key, (old) => {
+      const snapshot = Array.isArray(old) ? [...old] : old;
+      return updater(snapshot);
+    });
+  });
+}
+
+function getExistingOpportunity(
+  queries: Array<[QueryKey, Opportunity[] | undefined]>,
+  id: string,
+): Opportunity | undefined {
+  for (const [, data] of queries) {
+    const match = data?.find((item) => item.id === id);
+    if (match) {
+      return match;
+    }
+  }
+
+  return undefined;
+}
+
+export function usePipelineQuery(filters?: OpportunityFilters) {
+  const dispatch = useAppDispatch();
+  const storedFilters = useAppSelector(selectPipelineFilters);
+  const activeFilters = filters ?? storedFilters ?? null;
+  const queryKey = getPipelineQueryKey(activeFilters);
+
+  useEffect(() => {
+    if (filters !== undefined) {
+      dispatch(setPipelineFilters(filters));
+    }
+  }, [dispatch, filters]);
+
+  return useQuery({
+    queryKey,
+    queryFn: async () => {
+      dispatch(setPipelineStatus('loading'));
+      const result = await listOpportunities(activeFilters ?? undefined);
+      assertSuccess(result);
+      return result.data;
+    },
+    staleTime: 30_000,
+    onSuccess: (data) => {
+      dispatch(replacePipeline(data));
+      dispatch(setPipelineStatus('succeeded'));
+      dispatch(setPipelineError(null));
+      dispatch(setPipelineLastUpdatedAt(Date.now()));
+      if (filters === undefined) {
+        dispatch(setPipelineFilters(activeFilters));
+      }
+    },
+    onError: (error) => {
+      dispatch(setPipelineStatus('failed'));
+      dispatch(
+        setPipelineError(
+          getErrorMessage(error, 'Não foi possível carregar o pipeline.'),
+        ),
+      );
+    },
+  });
+}
+
+export function useCreateOpportunityMutation() {
+  const dispatch = useAppDispatch();
+  const queryClient = useQueryClient();
+
+  return useMutation<Opportunity, unknown, CreateOpportunityPayload, PipelineQueryContext>({
+    mutationFn: async (payload) => {
+      const result = await createOpportunity(payload);
+      assertSuccess(result);
+      return result.data;
+    },
+    onMutate: async (payload) => {
+      dispatch(setPipelineStatus('loading'));
+      await queryClient.cancelQueries({ queryKey: PIPELINE_QUERY_KEY });
+
+      const previousQueries = queryClient.getQueriesData<Opportunity[]>({
+        queryKey: PIPELINE_QUERY_KEY,
+      });
+
+      const optimisticOpportunity: Opportunity = {
+        id: generateOptimisticId(),
+        name: payload.name,
+        stage: payload.stage,
+        region: payload.region,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        valuation: payload.valuation,
+        probability: payload.probability ?? 0,
+        metadata: payload.metadata,
+      };
+
+      applyToAllPipelineQueries(queryClient, (data) => [
+        optimisticOpportunity,
+        ...(data ?? []),
+      ]);
+
+      dispatch(upsertPipelineOpportunity(optimisticOpportunity));
+      dispatch(markPipelineOptimistic(optimisticOpportunity.id));
+
+      return { previousQueries, optimisticOpportunity };
+    },
+    onError: (error, _payload, context) => {
+      context?.previousQueries.forEach(([key, data]) => {
+        queryClient.setQueryData(key, data);
+      });
+
+      if (context?.optimisticOpportunity) {
+        dispatch(removePipelineOpportunity(context.optimisticOpportunity.id));
+        dispatch(clearPipelineOptimistic(context.optimisticOpportunity.id));
+      }
+
+      dispatch(
+        setPipelineError(
+          getErrorMessage(error, 'Não foi possível criar a oportunidade.'),
+        ),
+      );
+      dispatch(setPipelineStatus('failed'));
+    },
+    onSuccess: (opportunity, _payload, context) => {
+      if (context?.optimisticOpportunity) {
+        dispatch(clearPipelineOptimistic(context.optimisticOpportunity.id));
+        dispatch(removePipelineOpportunity(context.optimisticOpportunity.id));
+      }
+
+      dispatch(upsertPipelineOpportunity(opportunity));
+      applyToAllPipelineQueries(queryClient, (data) => {
+        const withoutOptimistic = (data ?? []).filter(
+          (item) => item.id !== context?.optimisticOpportunity?.id,
+        );
+        return [opportunity, ...withoutOptimistic];
+      });
+
+      dispatch(setPipelineStatus('succeeded'));
+      dispatch(setPipelineError(null));
+      dispatch(setPipelineLastUpdatedAt(Date.now()));
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: PIPELINE_QUERY_KEY });
+    },
+  });
+}
+
+export function useUpdateOpportunityMutation() {
+  const dispatch = useAppDispatch();
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    Opportunity,
+    unknown,
+    { id: string; payload: UpdateOpportunityPayload },
+    PipelineQueryContext & { baseline?: Opportunity }
+  >({
+    mutationFn: async ({ id, payload }) => {
+      const result = await updateOpportunity(id, payload);
+      assertSuccess(result);
+      return result.data;
+    },
+    onMutate: async ({ id, payload }) => {
+      dispatch(setPipelineStatus('loading'));
+      await queryClient.cancelQueries({ queryKey: PIPELINE_QUERY_KEY });
+
+      const previousQueries = queryClient.getQueriesData<Opportunity[]>({
+        queryKey: PIPELINE_QUERY_KEY,
+      });
+
+      const baseline = getExistingOpportunity(previousQueries, id);
+      const optimisticOpportunity: Opportunity = {
+        ...(baseline ?? {
+          id,
+          name: payload.name ?? 'Oportunidade',
+          stage: payload.stage ?? 'lead',
+          createdAt: new Date().toISOString(),
+        }),
+        ...payload,
+        updatedAt: new Date().toISOString(),
+      };
+
+      applyToAllPipelineQueries(queryClient, (data) => {
+        if (!data) {
+          return [optimisticOpportunity];
+        }
+
+        return data.map((item) => (item.id === id ? optimisticOpportunity : item));
+      });
+
+      dispatch(upsertPipelineOpportunity(optimisticOpportunity));
+      dispatch(markPipelineOptimistic(id));
+
+      return { previousQueries, optimisticOpportunity, baseline };
+    },
+    onError: (error, variables, context) => {
+      context?.previousQueries.forEach(([key, data]) => {
+        queryClient.setQueryData(key, data);
+      });
+
+      if (context?.baseline) {
+        dispatch(upsertPipelineOpportunity(context.baseline));
+      }
+
+      dispatch(clearPipelineOptimistic(variables.id));
+      dispatch(
+        setPipelineError(
+          getErrorMessage(error, 'Não foi possível atualizar a oportunidade.'),
+        ),
+      );
+      dispatch(setPipelineStatus('failed'));
+    },
+    onSuccess: (opportunity) => {
+      dispatch(clearPipelineOptimistic(opportunity.id));
+      dispatch(upsertPipelineOpportunity(opportunity));
+      applyToAllPipelineQueries(queryClient, (data) => {
+        if (!data) {
+          return [opportunity];
+        }
+
+        return data.map((item) => (item.id === opportunity.id ? opportunity : item));
+      });
+      dispatch(setPipelineStatus('succeeded'));
+      dispatch(setPipelineError(null));
+      dispatch(setPipelineLastUpdatedAt(Date.now()));
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: PIPELINE_QUERY_KEY });
+    },
+  });
+}
+
+export function useDeleteOpportunityMutation() {
+  const dispatch = useAppDispatch();
+  const queryClient = useQueryClient();
+
+  return useMutation<string, unknown, string, PipelineQueryContext & { baseline?: Opportunity }>(
+    {
+      mutationFn: async (id) => {
+        const result = await deleteOpportunity(id);
+        assertSuccess(result);
+        return id;
+      },
+      onMutate: async (id) => {
+        dispatch(setPipelineStatus('loading'));
+        await queryClient.cancelQueries({ queryKey: PIPELINE_QUERY_KEY });
+
+        const previousQueries = queryClient.getQueriesData<Opportunity[]>({
+          queryKey: PIPELINE_QUERY_KEY,
+        });
+
+        const baseline = getExistingOpportunity(previousQueries, id);
+
+        applyToAllPipelineQueries(queryClient, (data) =>
+          (data ?? []).filter((item) => item.id !== id),
+        );
+
+        if (baseline) {
+          dispatch(removePipelineOpportunity(id));
+        }
+
+        dispatch(markPipelineOptimistic(id));
+
+        return { previousQueries, baseline };
+      },
+      onError: (error, id, context) => {
+        context?.previousQueries.forEach(([key, data]) => {
+          queryClient.setQueryData(key, data);
+        });
+
+        if (context?.baseline) {
+          dispatch(upsertPipelineOpportunity(context.baseline));
+        }
+
+        dispatch(clearPipelineOptimistic(id));
+        dispatch(
+          setPipelineError(
+            getErrorMessage(error, 'Não foi possível remover a oportunidade.'),
+          ),
+        );
+        dispatch(setPipelineStatus('failed'));
+      },
+      onSuccess: (id) => {
+        dispatch(removePipelineOpportunity(id));
+        dispatch(clearPipelineOptimistic(id));
+        applyToAllPipelineQueries(queryClient, (data) =>
+          (data ?? []).filter((item) => item.id !== id),
+        );
+        dispatch(setPipelineStatus('succeeded'));
+        dispatch(setPipelineError(null));
+        dispatch(setPipelineLastUpdatedAt(Date.now()));
+      },
+      onSettled: () => {
+        queryClient.invalidateQueries({ queryKey: PIPELINE_QUERY_KEY });
+      },
+    },
+  );
+}
+
+export { PIPELINE_QUERY_KEY };

--- a/src/hooks/usePortfolioQueries.ts
+++ b/src/hooks/usePortfolioQueries.ts
@@ -1,0 +1,118 @@
+import { useEffect } from 'react';
+import { useQuery, useQueryClient, type QueryKey } from '@tanstack/react-query';
+
+import {
+  assertPortfolioSuccess,
+  fetchPortfolioSnapshot,
+  type PortfolioFilters,
+} from '@/services/portfolioService';
+import {
+  selectActivePortfolioId,
+  setActivePortfolioId,
+  setPortfolioError,
+  setPortfolioSnapshot,
+  setPortfolioStatus,
+} from '@/store/portfolioSlice';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
+import { getErrorMessage } from '@/utils/errors';
+
+const PORTFOLIO_QUERY_KEY = ['portfolio'] as const;
+
+type PortfolioQueryKey = readonly [typeof PORTFOLIO_QUERY_KEY[0], string, ...unknown[]];
+
+function normalizeFilters(filters?: PortfolioFilters | null) {
+  if (!filters) {
+    return null;
+  }
+
+  const entries = Object.entries(filters).filter(([, value]) =>
+    value !== undefined && value !== null && value !== '',
+  );
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return Object.fromEntries(entries) as PortfolioFilters;
+}
+
+export function getPortfolioQueryKey(
+  portfolioId: string,
+  filters?: PortfolioFilters | null,
+): PortfolioQueryKey {
+  const normalized = normalizeFilters(filters);
+  if (!normalized) {
+    return [...PORTFOLIO_QUERY_KEY, portfolioId];
+  }
+
+  return [...PORTFOLIO_QUERY_KEY, portfolioId, normalized];
+}
+
+export function usePortfolioSnapshotQuery(
+  options?: {
+    portfolioId?: string;
+    filters?: PortfolioFilters;
+    enabled?: boolean;
+  },
+) {
+  const dispatch = useAppDispatch();
+  const activePortfolioId = useAppSelector(selectActivePortfolioId);
+  const portfolioId = options?.portfolioId ?? activePortfolioId;
+  const filters = options?.filters;
+  const queryKey = getPortfolioQueryKey(portfolioId, filters ?? null);
+
+  useEffect(() => {
+    if (options?.portfolioId) {
+      dispatch(setActivePortfolioId(options.portfolioId));
+      return;
+    }
+
+    if (!activePortfolioId && portfolioId) {
+      dispatch(setActivePortfolioId(portfolioId));
+    }
+  }, [dispatch, options?.portfolioId, activePortfolioId, portfolioId]);
+
+  return useQuery({
+    queryKey,
+    enabled: (options?.enabled ?? true) && Boolean(portfolioId),
+    queryFn: async () => {
+      dispatch(setPortfolioStatus({ portfolioId, status: 'loading' }));
+      const result = await fetchPortfolioSnapshot({
+        portfolioId,
+        ...filters,
+      });
+      assertPortfolioSuccess(result);
+      return result.data;
+    },
+    staleTime: 60_000,
+    onSuccess: (data) => {
+      dispatch(setPortfolioSnapshot({ portfolioId, snapshot: data }));
+      dispatch(setPortfolioStatus({ portfolioId, status: 'succeeded' }));
+      dispatch(setPortfolioError({ portfolioId, error: null }));
+    },
+    onError: (error) => {
+      dispatch(setPortfolioStatus({ portfolioId, status: 'failed' }));
+      dispatch(
+        setPortfolioError({
+          portfolioId,
+          error: getErrorMessage(
+            error,
+            'Não foi possível carregar os dados do portfólio.',
+          ),
+        }),
+      );
+    },
+  });
+}
+
+export function useInvalidatePortfolioSnapshot() {
+  const queryClient = useQueryClient();
+  return (portfolioId?: string) => {
+    const partialKey: QueryKey = portfolioId
+      ? [PORTFOLIO_QUERY_KEY[0], portfolioId]
+      : [PORTFOLIO_QUERY_KEY[0]];
+    return queryClient.invalidateQueries({ queryKey: partialKey });
+  };
+}
+
+export { PORTFOLIO_QUERY_KEY };

--- a/src/services/dashboardService.ts
+++ b/src/services/dashboardService.ts
@@ -1,0 +1,144 @@
+import httpClient, {
+  type HttpClientError,
+  type HttpRequestConfig,
+  type HttpSuccessResponse,
+  normalizeHttpError,
+  toHttpSuccessResponse,
+} from './httpClient';
+
+export type DashboardTimeframe = '7d' | '30d' | '90d' | '180d';
+
+export interface DashboardMetric {
+  id: string;
+  label: string;
+  value: number;
+  unit?: string;
+  change?: number;
+  trend?: 'up' | 'down' | 'steady';
+  description?: string;
+}
+
+export interface DashboardBreakdownItem {
+  id: string;
+  label: string;
+  value: number;
+  percentage?: number;
+}
+
+export interface DashboardHighlight {
+  id: string;
+  title: string;
+  description: string;
+  impact?: number;
+  probability?: number;
+}
+
+export interface DashboardSummary {
+  scope: string;
+  timeframe?: DashboardTimeframe;
+  updatedAt: string;
+  metrics: DashboardMetric[];
+  breakdowns: DashboardBreakdownItem[];
+  highlights: DashboardHighlight[];
+}
+
+export interface DashboardFilters {
+  scope?: string;
+  timeframe?: DashboardTimeframe;
+  portfolioId?: string;
+  [key: string]: unknown;
+}
+
+export interface DashboardServiceSuccess<TData>
+  extends HttpSuccessResponse<TData> {
+  success: true;
+}
+
+export interface DashboardServiceError {
+  success: false;
+  status?: number;
+  error: HttpClientError;
+}
+
+export type DashboardServiceResult<TData> =
+  | DashboardServiceSuccess<TData>
+  | DashboardServiceError;
+
+const BASE_PATH = '/dashboards';
+
+function toServiceSuccess<TData>(
+  response: HttpSuccessResponse<TData>,
+): DashboardServiceSuccess<TData> {
+  return {
+    success: true,
+    ...response,
+  };
+}
+
+function toServiceError(error: unknown): DashboardServiceError {
+  const normalized = normalizeHttpError(error);
+  return {
+    success: false,
+    status: normalized.status,
+    error: normalized,
+  };
+}
+
+function mergeParams(
+  base: HttpRequestConfig['params'],
+  extras: Record<string, unknown> | undefined,
+) {
+  if (!extras) {
+    return base;
+  }
+
+  return {
+    ...(typeof base === 'object' && base != null ? base : {}),
+    ...extras,
+  };
+}
+
+function sanitizeFilters(filters?: DashboardFilters) {
+  if (!filters) {
+    return undefined;
+  }
+
+  const entries = Object.entries(filters).filter(([, value]) => {
+    return value !== undefined && value !== null && value !== '';
+  });
+
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  return Object.fromEntries(entries);
+}
+
+export async function fetchDashboardSummary(
+  filters?: DashboardFilters,
+  config?: HttpRequestConfig,
+): Promise<DashboardServiceResult<DashboardSummary>> {
+  try {
+    const requestConfig: HttpRequestConfig = {
+      ...config,
+      params: mergeParams(config?.params, sanitizeFilters(filters)),
+    };
+
+    const response = await httpClient.get<DashboardSummary>(
+      `${BASE_PATH}/summary`,
+      requestConfig,
+    );
+
+    return toServiceSuccess(toHttpSuccessResponse(response));
+  } catch (error) {
+    return toServiceError(error);
+  }
+}
+
+export function assertDashboardSuccess<TData>(
+  result: DashboardServiceResult<TData>,
+): asserts result is DashboardServiceSuccess<TData> {
+  if (!result.success) {
+    throw result.error;
+  }
+}

--- a/src/services/portfolioService.ts
+++ b/src/services/portfolioService.ts
@@ -1,0 +1,143 @@
+import httpClient, {
+  type HttpClientError,
+  type HttpRequestConfig,
+  type HttpSuccessResponse,
+  normalizeHttpError,
+  toHttpSuccessResponse,
+} from './httpClient';
+
+export interface PortfolioTotals {
+  invested: number;
+  currentValue: number;
+  netIncome: number;
+  occupancy: number;
+  irr: number;
+}
+
+export interface PortfolioPosition {
+  id: string;
+  name: string;
+  allocation: number;
+  invested: number;
+  currentValue: number;
+  irr: number;
+  occupancy: number;
+  status: 'up' | 'down' | 'steady';
+}
+
+export interface PortfolioEvent {
+  id: string;
+  title: string;
+  date: string;
+  type: string;
+  description?: string;
+}
+
+export interface PortfolioSnapshot {
+  portfolioId: string;
+  updatedAt: string;
+  totals: PortfolioTotals;
+  positions: PortfolioPosition[];
+  events: PortfolioEvent[];
+}
+
+export interface PortfolioFilters {
+  portfolioId?: string;
+  asOf?: string;
+  includeEvents?: boolean;
+  [key: string]: unknown;
+}
+
+export interface PortfolioServiceSuccess<TData>
+  extends HttpSuccessResponse<TData> {
+  success: true;
+}
+
+export interface PortfolioServiceError {
+  success: false;
+  status?: number;
+  error: HttpClientError;
+}
+
+export type PortfolioServiceResult<TData> =
+  | PortfolioServiceSuccess<TData>
+  | PortfolioServiceError;
+
+const BASE_PATH = '/portfolio';
+
+function toServiceSuccess<TData>(
+  response: HttpSuccessResponse<TData>,
+): PortfolioServiceSuccess<TData> {
+  return {
+    success: true,
+    ...response,
+  };
+}
+
+function toServiceError(error: unknown): PortfolioServiceError {
+  const normalized = normalizeHttpError(error);
+  return {
+    success: false,
+    status: normalized.status,
+    error: normalized,
+  };
+}
+
+function mergeParams(
+  base: HttpRequestConfig['params'],
+  extras: Record<string, unknown> | undefined,
+) {
+  if (!extras) {
+    return base;
+  }
+
+  return {
+    ...(typeof base === 'object' && base != null ? base : {}),
+    ...extras,
+  };
+}
+
+function sanitizeFilters(filters?: PortfolioFilters) {
+  if (!filters) {
+    return undefined;
+  }
+
+  const entries = Object.entries(filters).filter(([, value]) => {
+    return value !== undefined && value !== null && value !== '';
+  });
+
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  return Object.fromEntries(entries);
+}
+
+export async function fetchPortfolioSnapshot(
+  filters?: PortfolioFilters,
+  config?: HttpRequestConfig,
+): Promise<PortfolioServiceResult<PortfolioSnapshot>> {
+  try {
+    const requestConfig: HttpRequestConfig = {
+      ...config,
+      params: mergeParams(config?.params, sanitizeFilters(filters)),
+    };
+
+    const response = await httpClient.get<PortfolioSnapshot>(
+      `${BASE_PATH}/snapshot`,
+      requestConfig,
+    );
+
+    return toServiceSuccess(toHttpSuccessResponse(response));
+  } catch (error) {
+    return toServiceError(error);
+  }
+}
+
+export function assertPortfolioSuccess<TData>(
+  result: PortfolioServiceResult<TData>,
+): asserts result is PortfolioServiceSuccess<TData> {
+  if (!result.success) {
+    throw result.error;
+  }
+}

--- a/src/services/realtime.ts
+++ b/src/services/realtime.ts
@@ -145,7 +145,7 @@ function appendTokenToUrl(url: string, token: string | null): string {
     const parsed = new URL(url, base);
     parsed.searchParams.set('token', token);
     return parsed.toString();
-  } catch (error) {
+  } catch {
     const separator = url.includes('?') ? '&' : '?';
     return `${url}${separator}token=${encodeURIComponent(token)}`;
   }
@@ -227,7 +227,7 @@ function parseRealtimeMessage(event: MessageEvent): RealtimeMessage {
       } else {
         data = parsed;
       }
-    } catch (error) {
+    } catch {
       data = event.data;
     }
   } else if (
@@ -282,11 +282,9 @@ function scheduleReconnect() {
   reconnectAttempts = attempt;
 }
 
-async function createSocket(
-  options: InternalRealtimeOptions,
-): Promise<WebSocket> {
-  return new Promise(async (resolve, reject) => {
-    try {
+function createSocket(options: InternalRealtimeOptions): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    (async () => {
       const token = await resolveToken(options.token);
       const targetUrl = appendTokenToUrl(
         resolveRealtimeUrl(options.url),
@@ -328,7 +326,9 @@ async function createSocket(
         if (!settled) {
           settled = true;
           reject(
-            new Error(`Realtime connection closed before opening (code ${event.code})`),
+            new Error(
+              `Realtime connection closed before opening (code ${event.code})`,
+            ),
           );
         }
 
@@ -366,9 +366,9 @@ async function createSocket(
       socket.addEventListener('error', handleError);
 
       activeCleanup = cleanup;
-    } catch (error) {
+    })().catch((error) => {
       reject(error instanceof Error ? error : new Error(String(error)));
-    }
+    });
   });
 }
 

--- a/src/store/dashboardsSlice.ts
+++ b/src/store/dashboardsSlice.ts
@@ -1,0 +1,230 @@
+import { createAsyncThunk, createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+import type { RootState } from './index';
+import type {
+  DashboardFilters,
+  DashboardSummary,
+  DashboardTimeframe,
+} from '@/services/dashboardService';
+import {
+  assertDashboardSuccess,
+  fetchDashboardSummary,
+} from '@/services/dashboardService';
+import type { RequestStatus } from './pipelineSlice';
+
+interface DashboardState {
+  summaries: Record<string, DashboardSummary | null>;
+  statusByScope: Record<string, RequestStatus>;
+  errorByScope: Record<string, string | null>;
+  timeframeByScope: Record<string, DashboardTimeframe>;
+  lastFetchedAt: Record<string, number | null>;
+}
+
+const DEFAULT_TIMEFRAME: DashboardTimeframe = '30d';
+
+const initialState: DashboardState = {
+  summaries: {},
+  statusByScope: {},
+  errorByScope: {},
+  timeframeByScope: {},
+  lastFetchedAt: {},
+};
+
+function resolveScopeStatus(state: DashboardState, scope: string) {
+  if (!state.statusByScope[scope]) {
+    state.statusByScope[scope] = 'idle';
+  }
+}
+
+function resolveScopeError(state: DashboardState, scope: string) {
+  if (!(scope in state.errorByScope)) {
+    state.errorByScope[scope] = null;
+  }
+}
+
+function resolveScopeTimeframe(state: DashboardState, scope: string) {
+  if (!state.timeframeByScope[scope]) {
+    state.timeframeByScope[scope] = DEFAULT_TIMEFRAME;
+  }
+}
+
+function resolveScopeTimestamp(state: DashboardState, scope: string) {
+  if (!(scope in state.lastFetchedAt)) {
+    state.lastFetchedAt[scope] = null;
+  }
+}
+
+function resolveErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (error && typeof error === 'object' && 'message' in error) {
+    const value = (error as { message?: unknown }).message;
+    if (typeof value === 'string') {
+      return value;
+    }
+  }
+
+  return 'Não foi possível carregar os indicadores.';
+}
+
+export const fetchDashboards = createAsyncThunk<
+  { scope: string; summary: DashboardSummary; receivedAt: number },
+  { scope: string; filters?: DashboardFilters },
+  { rejectValue: { scope: string; error: string } }
+>('dashboards/fetchSummary', async ({ scope, filters }, { rejectWithValue }) => {
+  try {
+    const result = await fetchDashboardSummary({ scope, ...filters });
+    assertDashboardSuccess(result);
+    return {
+      scope,
+      summary: result.data,
+      receivedAt: Date.now(),
+    };
+  } catch (error) {
+    return rejectWithValue({
+      scope,
+      error: resolveErrorMessage(error),
+    });
+  }
+});
+
+const dashboardsSlice = createSlice({
+  name: 'dashboards',
+  initialState,
+  reducers: {
+    setDashboardSummary(
+      state,
+      action: PayloadAction<{ scope: string; summary: DashboardSummary }>,
+    ) {
+      const { scope, summary } = action.payload;
+      state.summaries[scope] = summary;
+      resolveScopeTimestamp(state, scope);
+      state.lastFetchedAt[scope] = Date.now();
+    },
+    setDashboardStatus(
+      state,
+      action: PayloadAction<{ scope: string; status: RequestStatus }>,
+    ) {
+      const { scope, status } = action.payload;
+      resolveScopeStatus(state, scope);
+      state.statusByScope[scope] = status;
+      if (status !== 'failed') {
+        resolveScopeError(state, scope);
+        state.errorByScope[scope] = null;
+      }
+    },
+    setDashboardError(
+      state,
+      action: PayloadAction<{ scope: string; error: string | null }>,
+    ) {
+      const { scope, error } = action.payload;
+      resolveScopeError(state, scope);
+      state.errorByScope[scope] = error;
+      if (error) {
+        resolveScopeStatus(state, scope);
+        state.statusByScope[scope] = 'failed';
+      }
+    },
+    setDashboardTimeframe(
+      state,
+      action: PayloadAction<{ scope: string; timeframe: DashboardTimeframe }>,
+    ) {
+      const { scope, timeframe } = action.payload;
+      state.timeframeByScope[scope] = timeframe;
+    },
+    resetDashboardState(state, action: PayloadAction<string | undefined>) {
+      const scope = action.payload;
+      if (!scope) {
+        state.summaries = {};
+        state.statusByScope = {};
+        state.errorByScope = {};
+        state.timeframeByScope = {};
+        state.lastFetchedAt = {};
+        return;
+      }
+
+      delete state.summaries[scope];
+      delete state.statusByScope[scope];
+      delete state.errorByScope[scope];
+      delete state.timeframeByScope[scope];
+      delete state.lastFetchedAt[scope];
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchDashboards.pending, (state, action) => {
+        const { scope } = action.meta.arg;
+        resolveScopeStatus(state, scope);
+        resolveScopeError(state, scope);
+        resolveScopeTimeframe(state, scope);
+        resolveScopeTimestamp(state, scope);
+        state.statusByScope[scope] = 'loading';
+        state.errorByScope[scope] = null;
+      })
+      .addCase(fetchDashboards.fulfilled, (state, action) => {
+        const { scope, summary, receivedAt } = action.payload;
+        state.summaries[scope] = summary;
+        resolveScopeStatus(state, scope);
+        resolveScopeError(state, scope);
+        state.statusByScope[scope] = 'succeeded';
+        state.errorByScope[scope] = null;
+        resolveScopeTimestamp(state, scope);
+        state.lastFetchedAt[scope] = receivedAt;
+        resolveScopeTimeframe(state, scope);
+        state.timeframeByScope[scope] = summary.timeframe ?? state.timeframeByScope[scope];
+      })
+      .addCase(fetchDashboards.rejected, (state, action) => {
+        if (!action.payload) {
+          return;
+        }
+
+        const { scope, error } = action.payload;
+        resolveScopeStatus(state, scope);
+        resolveScopeError(state, scope);
+        state.statusByScope[scope] = 'failed';
+        state.errorByScope[scope] = error;
+      });
+  },
+});
+
+export const {
+  setDashboardSummary,
+  setDashboardStatus,
+  setDashboardError,
+  setDashboardTimeframe,
+  resetDashboardState,
+} = dashboardsSlice.actions;
+
+export default dashboardsSlice.reducer;
+
+export const selectDashboardSummary = (
+  state: RootState,
+  scope: string,
+): DashboardSummary | null => state.dashboards.summaries[scope] ?? null;
+
+export const selectDashboardStatus = (
+  state: RootState,
+  scope: string,
+): RequestStatus => state.dashboards.statusByScope[scope] ?? 'idle';
+
+export const selectDashboardError = (
+  state: RootState,
+  scope: string,
+): string | null => state.dashboards.errorByScope[scope] ?? null;
+
+export const selectDashboardTimeframe = (
+  state: RootState,
+  scope: string,
+): DashboardTimeframe =>
+  state.dashboards.timeframeByScope[scope] ?? DEFAULT_TIMEFRAME;
+
+export const selectDashboardLastFetchedAt = (
+  state: RootState,
+  scope: string,
+): number | null => state.dashboards.lastFetchedAt[scope] ?? null;

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -1,0 +1,7 @@
+import { useDispatch, useSelector, type TypedUseSelectorHook } from 'react-redux';
+
+import type { AppDispatch, RootState } from './index';
+
+export const useAppDispatch: () => AppDispatch = useDispatch;
+
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,7 +1,15 @@
 import { configureStore } from '@reduxjs/toolkit';
 
+import dashboardsReducer from './dashboardsSlice';
+import pipelineReducer from './pipelineSlice';
+import portfolioReducer from './portfolioSlice';
+
 export const store = configureStore({
-  reducer: {},
+  reducer: {
+    pipeline: pipelineReducer,
+    dashboards: dashboardsReducer,
+    portfolio: portfolioReducer,
+  },
 });
 
 export type RootState = ReturnType<typeof store.getState>;

--- a/src/store/pipelineSlice.ts
+++ b/src/store/pipelineSlice.ts
@@ -1,0 +1,339 @@
+import {
+  createAsyncThunk,
+  createEntityAdapter,
+  createSelector,
+  createSlice,
+  type EntityState,
+  type PayloadAction,
+} from '@reduxjs/toolkit';
+
+import type {
+  CreateOpportunityPayload,
+  Opportunity,
+  OpportunityFilters,
+  UpdateOpportunityPayload,
+} from '@/services/opportunitiesService';
+import {
+  assertSuccess,
+  createOpportunity,
+  deleteOpportunity,
+  listOpportunities,
+  updateOpportunity,
+} from '@/services/opportunitiesService';
+
+import type { RootState } from './index';
+
+export type RequestStatus = 'idle' | 'loading' | 'succeeded' | 'failed';
+
+type PipelineEntityState = EntityState<Opportunity>;
+
+export interface PipelineState extends PipelineEntityState {
+  status: RequestStatus;
+  error: string | null;
+  filters: OpportunityFilters | null;
+  lastUpdatedAt: number | null;
+  optimisticIds: string[];
+}
+
+const pipelineAdapter = createEntityAdapter<Opportunity>({
+  selectId: (opportunity) => opportunity.id,
+  sortComparer: (a, b) =>
+    new Date(b.updatedAt ?? b.createdAt).getTime() -
+    new Date(a.updatedAt ?? a.createdAt).getTime(),
+});
+
+const initialState: PipelineState = pipelineAdapter.getInitialState({
+  status: 'idle',
+  error: null,
+  filters: null,
+  lastUpdatedAt: null,
+  optimisticIds: [],
+});
+
+function resolveErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (error && typeof error === 'object' && 'message' in error) {
+    const value = (error as { message?: unknown }).message;
+    if (typeof value === 'string') {
+      return value;
+    }
+  }
+
+  return 'Não foi possível concluir a operação.';
+}
+
+export const fetchPipeline = createAsyncThunk<
+  { opportunities: Opportunity[]; receivedAt: number; filters?: OpportunityFilters },
+  OpportunityFilters | undefined,
+  { rejectValue: string }
+>('pipeline/fetchPipeline', async (filters, { rejectWithValue }) => {
+  try {
+    const result = await listOpportunities(filters);
+    assertSuccess(result);
+    return {
+      opportunities: result.data,
+      receivedAt: Date.now(),
+      filters,
+    };
+  } catch (error) {
+    return rejectWithValue(resolveErrorMessage(error));
+  }
+});
+
+export const createPipelineOpportunity = createAsyncThunk<
+  Opportunity,
+  CreateOpportunityPayload,
+  { rejectValue: string }
+>('pipeline/createOpportunity', async (payload, { rejectWithValue }) => {
+  try {
+    const result = await createOpportunity(payload);
+    assertSuccess(result);
+    return result.data;
+  } catch (error) {
+    return rejectWithValue(resolveErrorMessage(error));
+  }
+});
+
+export const updatePipelineOpportunity = createAsyncThunk<
+  Opportunity,
+  { id: string; payload: UpdateOpportunityPayload },
+  { rejectValue: string }
+>('pipeline/updateOpportunity', async ({ id, payload }, { rejectWithValue }) => {
+  try {
+    const result = await updateOpportunity(id, payload);
+    assertSuccess(result);
+    return result.data;
+  } catch (error) {
+    return rejectWithValue(resolveErrorMessage(error));
+  }
+});
+
+export const deletePipelineOpportunity = createAsyncThunk<
+  string,
+  string,
+  { rejectValue: string }
+>('pipeline/deleteOpportunity', async (id, { rejectWithValue }) => {
+  try {
+    const result = await deleteOpportunity(id);
+    assertSuccess(result);
+    return id;
+  } catch (error) {
+    return rejectWithValue(resolveErrorMessage(error));
+  }
+});
+
+const pipelineSlice = createSlice({
+  name: 'pipeline',
+  initialState,
+  reducers: {
+    setFilters(state, action: PayloadAction<OpportunityFilters | null | undefined>) {
+      state.filters = action.payload ?? null;
+    },
+    setStatus(state, action: PayloadAction<RequestStatus>) {
+      state.status = action.payload;
+      if (action.payload !== 'failed') {
+        state.error = null;
+      }
+    },
+    setError(state, action: PayloadAction<string | null>) {
+      state.error = action.payload;
+      if (action.payload) {
+        state.status = 'failed';
+      }
+    },
+    setLastUpdatedAt(state, action: PayloadAction<number | null>) {
+      state.lastUpdatedAt = action.payload ?? null;
+    },
+    upsertOpportunity: pipelineAdapter.upsertOne,
+    upsertMany: pipelineAdapter.upsertMany,
+    removeOpportunity: pipelineAdapter.removeOne,
+    setAll: pipelineAdapter.setAll,
+    markOptimistic(state, action: PayloadAction<string>) {
+      if (!state.optimisticIds.includes(action.payload)) {
+        state.optimisticIds.push(action.payload);
+      }
+    },
+    clearOptimistic(state, action: PayloadAction<string>) {
+      state.optimisticIds = state.optimisticIds.filter(
+        (id) => id !== action.payload,
+      );
+    },
+    resetOptimistic(state) {
+      state.optimisticIds = [];
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchPipeline.pending, (state, action) => {
+        state.status = 'loading';
+        state.error = null;
+        if (action.meta.arg !== undefined) {
+          state.filters = action.meta.arg ?? null;
+        }
+      })
+      .addCase(fetchPipeline.fulfilled, (state, action) => {
+        pipelineAdapter.setAll(state, action.payload.opportunities);
+        state.status = 'succeeded';
+        state.error = null;
+        state.lastUpdatedAt = action.payload.receivedAt;
+        state.filters = action.payload.filters ?? null;
+      })
+      .addCase(fetchPipeline.rejected, (state, action) => {
+        state.status = 'failed';
+        state.error = action.payload ?? 'Não foi possível carregar o pipeline.';
+      })
+      .addCase(createPipelineOpportunity.pending, (state) => {
+        state.status = 'loading';
+        state.error = null;
+      })
+      .addCase(createPipelineOpportunity.fulfilled, (state, action) => {
+        pipelineAdapter.upsertOne(state, action.payload);
+        state.status = 'succeeded';
+        state.error = null;
+        state.lastUpdatedAt = Date.now();
+      })
+      .addCase(createPipelineOpportunity.rejected, (state, action) => {
+        state.status = 'failed';
+        state.error = action.payload ?? 'Não foi possível criar a oportunidade.';
+      })
+      .addCase(updatePipelineOpportunity.pending, (state, action) => {
+        state.status = 'loading';
+        state.error = null;
+        state.optimisticIds = Array.from(
+          new Set([...state.optimisticIds, action.meta.arg.id]),
+        );
+      })
+      .addCase(updatePipelineOpportunity.fulfilled, (state, action) => {
+        pipelineAdapter.upsertOne(state, action.payload);
+        state.status = 'succeeded';
+        state.error = null;
+        state.lastUpdatedAt = Date.now();
+        state.optimisticIds = state.optimisticIds.filter(
+          (id) => id !== action.payload.id,
+        );
+      })
+      .addCase(updatePipelineOpportunity.rejected, (state, action) => {
+        state.status = 'failed';
+        state.error = action.payload ?? 'Não foi possível atualizar a oportunidade.';
+      })
+      .addCase(deletePipelineOpportunity.pending, (state, action) => {
+        state.status = 'loading';
+        state.error = null;
+        state.optimisticIds = Array.from(
+          new Set([...state.optimisticIds, action.meta.arg]),
+        );
+      })
+      .addCase(deletePipelineOpportunity.fulfilled, (state, action) => {
+        pipelineAdapter.removeOne(state, action.payload);
+        state.status = 'succeeded';
+        state.error = null;
+        state.lastUpdatedAt = Date.now();
+        state.optimisticIds = state.optimisticIds.filter(
+          (id) => id !== action.payload,
+        );
+      })
+      .addCase(deletePipelineOpportunity.rejected, (state, action) => {
+        state.status = 'failed';
+        state.error = action.payload ?? 'Não foi possível remover a oportunidade.';
+      });
+  },
+});
+
+export const {
+  setFilters: setPipelineFilters,
+  setStatus: setPipelineStatus,
+  setError: setPipelineError,
+  setLastUpdatedAt: setPipelineLastUpdatedAt,
+  upsertOpportunity: upsertPipelineOpportunity,
+  upsertMany: upsertManyPipelineOpportunities,
+  removeOpportunity: removePipelineOpportunity,
+  setAll: replacePipeline,
+  markOptimistic: markPipelineOptimistic,
+  clearOptimistic: clearPipelineOptimistic,
+  resetOptimistic: resetPipelineOptimistic,
+} = pipelineSlice.actions;
+
+export default pipelineSlice.reducer;
+
+const selectPipelineState = (state: RootState) => state.pipeline;
+
+const adapterSelectors = pipelineAdapter.getSelectors<RootState>(
+  (state) => state.pipeline,
+);
+
+export const selectAllPipelineOpportunities = adapterSelectors.selectAll;
+export const selectPipelineEntities = adapterSelectors.selectEntities;
+
+export const selectPipelineStatus = (state: RootState): RequestStatus =>
+  selectPipelineState(state).status;
+
+export const selectPipelineError = (state: RootState): string | null =>
+  selectPipelineState(state).error;
+
+export const selectPipelineFilters = (
+  state: RootState,
+): OpportunityFilters | null => selectPipelineState(state).filters;
+
+export const selectPipelineLastUpdatedAt = (state: RootState): number | null =>
+  selectPipelineState(state).lastUpdatedAt;
+
+export const selectPipelineOptimisticIds = (state: RootState): string[] =>
+  selectPipelineState(state).optimisticIds;
+
+export const selectPipelineByStage = createSelector(
+  [
+    selectAllPipelineOpportunities,
+    (_: RootState, stage?: string | null) => stage,
+  ],
+  (opportunities, stage) => {
+    if (!stage) {
+      return opportunities;
+    }
+
+    return opportunities.filter((opportunity) => opportunity.stage === stage);
+  },
+);
+
+export const selectPipelineTotals = createSelector(
+  [selectAllPipelineOpportunities],
+  (opportunities) => {
+    const totalValuation = opportunities.reduce((accumulator, opportunity) => {
+      const value = typeof opportunity.valuation === 'number'
+        ? opportunity.valuation
+        : Number(opportunity.valuation ?? 0);
+      return accumulator + (Number.isFinite(value) ? value : 0);
+    }, 0);
+
+    const averageProbability =
+      opportunities.length === 0
+        ? 0
+        :
+            opportunities.reduce((accumulator, opportunity) => {
+              const probability = Number(opportunity.probability ?? 0);
+              return accumulator + (Number.isFinite(probability) ? probability : 0);
+            }, 0) / opportunities.length;
+
+    return {
+      totalValuation,
+      averageProbability,
+      totalCount: opportunities.length,
+    };
+  },
+);
+
+export const selectIsOpportunityOptimistic = createSelector(
+  [
+    selectPipelineOptimisticIds,
+    (_: RootState, id: string | undefined) => id,
+  ],
+  (optimisticIds, id) => (id ? optimisticIds.includes(id) : false),
+);
+
+export type { Opportunity };

--- a/src/store/portfolioSlice.ts
+++ b/src/store/portfolioSlice.ts
@@ -1,0 +1,226 @@
+import { createAsyncThunk, createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+import type { RootState } from './index';
+import type {
+  PortfolioFilters,
+  PortfolioSnapshot,
+} from '@/services/portfolioService';
+import {
+  assertPortfolioSuccess,
+  fetchPortfolioSnapshot,
+} from '@/services/portfolioService';
+import type { RequestStatus } from './pipelineSlice';
+
+interface PortfolioState {
+  activePortfolioId: string;
+  snapshots: Record<string, PortfolioSnapshot | null>;
+  statusByPortfolio: Record<string, RequestStatus>;
+  errorByPortfolio: Record<string, string | null>;
+  lastFetchedAt: Record<string, number | null>;
+}
+
+const DEFAULT_PORTFOLIO_ID = 'all';
+
+const initialState: PortfolioState = {
+  activePortfolioId: DEFAULT_PORTFOLIO_ID,
+  snapshots: {},
+  statusByPortfolio: {},
+  errorByPortfolio: {},
+  lastFetchedAt: {},
+};
+
+function resolvePortfolioStatus(state: PortfolioState, portfolioId: string) {
+  if (!state.statusByPortfolio[portfolioId]) {
+    state.statusByPortfolio[portfolioId] = 'idle';
+  }
+}
+
+function resolvePortfolioError(state: PortfolioState, portfolioId: string) {
+  if (!(portfolioId in state.errorByPortfolio)) {
+    state.errorByPortfolio[portfolioId] = null;
+  }
+}
+
+function resolvePortfolioTimestamp(state: PortfolioState, portfolioId: string) {
+  if (!(portfolioId in state.lastFetchedAt)) {
+    state.lastFetchedAt[portfolioId] = null;
+  }
+}
+
+function resolveErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (error && typeof error === 'object' && 'message' in error) {
+    const value = (error as { message?: unknown }).message;
+    if (typeof value === 'string') {
+      return value;
+    }
+  }
+
+  return 'Não foi possível carregar os dados do portfólio.';
+}
+
+export const fetchPortfolio = createAsyncThunk<
+  { portfolioId: string; snapshot: PortfolioSnapshot; receivedAt: number },
+  { portfolioId: string; filters?: PortfolioFilters },
+  { rejectValue: { portfolioId: string; error: string } }
+>('portfolio/fetchSnapshot', async ({ portfolioId, filters }, { rejectWithValue }) => {
+  try {
+    const result = await fetchPortfolioSnapshot({
+      portfolioId,
+      ...filters,
+    });
+    assertPortfolioSuccess(result);
+    return {
+      portfolioId,
+      snapshot: result.data,
+      receivedAt: Date.now(),
+    };
+  } catch (error) {
+    return rejectWithValue({
+      portfolioId,
+      error: resolveErrorMessage(error),
+    });
+  }
+});
+
+const portfolioSlice = createSlice({
+  name: 'portfolio',
+  initialState,
+  reducers: {
+    setActivePortfolioId(state, action: PayloadAction<string>) {
+      state.activePortfolioId = action.payload;
+    },
+    setPortfolioSnapshot(
+      state,
+      action: PayloadAction<{ portfolioId: string; snapshot: PortfolioSnapshot }>,
+    ) {
+      const { portfolioId, snapshot } = action.payload;
+      state.snapshots[portfolioId] = snapshot;
+      resolvePortfolioTimestamp(state, portfolioId);
+      state.lastFetchedAt[portfolioId] = Date.now();
+    },
+    setPortfolioStatus(
+      state,
+      action: PayloadAction<{ portfolioId: string; status: RequestStatus }>,
+    ) {
+      const { portfolioId, status } = action.payload;
+      resolvePortfolioStatus(state, portfolioId);
+      state.statusByPortfolio[portfolioId] = status;
+      if (status !== 'failed') {
+        resolvePortfolioError(state, portfolioId);
+        state.errorByPortfolio[portfolioId] = null;
+      }
+    },
+    setPortfolioError(
+      state,
+      action: PayloadAction<{ portfolioId: string; error: string | null }>,
+    ) {
+      const { portfolioId, error } = action.payload;
+      resolvePortfolioError(state, portfolioId);
+      state.errorByPortfolio[portfolioId] = error;
+      if (error) {
+        resolvePortfolioStatus(state, portfolioId);
+        state.statusByPortfolio[portfolioId] = 'failed';
+      }
+    },
+    resetPortfolioState(state, action: PayloadAction<string | undefined>) {
+      const portfolioId = action.payload;
+      if (!portfolioId) {
+        state.snapshots = {};
+        state.statusByPortfolio = {};
+        state.errorByPortfolio = {};
+        state.lastFetchedAt = {};
+        return;
+      }
+
+      delete state.snapshots[portfolioId];
+      delete state.statusByPortfolio[portfolioId];
+      delete state.errorByPortfolio[portfolioId];
+      delete state.lastFetchedAt[portfolioId];
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchPortfolio.pending, (state, action) => {
+        const { portfolioId } = action.meta.arg;
+        resolvePortfolioStatus(state, portfolioId);
+        resolvePortfolioError(state, portfolioId);
+        resolvePortfolioTimestamp(state, portfolioId);
+        state.statusByPortfolio[portfolioId] = 'loading';
+        state.errorByPortfolio[portfolioId] = null;
+      })
+      .addCase(fetchPortfolio.fulfilled, (state, action) => {
+        const { portfolioId, snapshot, receivedAt } = action.payload;
+        state.snapshots[portfolioId] = snapshot;
+        resolvePortfolioStatus(state, portfolioId);
+        resolvePortfolioError(state, portfolioId);
+        state.statusByPortfolio[portfolioId] = 'succeeded';
+        state.errorByPortfolio[portfolioId] = null;
+        resolvePortfolioTimestamp(state, portfolioId);
+        state.lastFetchedAt[portfolioId] = receivedAt;
+      })
+      .addCase(fetchPortfolio.rejected, (state, action) => {
+        if (!action.payload) {
+          return;
+        }
+
+        const { portfolioId, error } = action.payload;
+        resolvePortfolioStatus(state, portfolioId);
+        resolvePortfolioError(state, portfolioId);
+        state.statusByPortfolio[portfolioId] = 'failed';
+        state.errorByPortfolio[portfolioId] = error;
+      });
+  },
+});
+
+export const {
+  setActivePortfolioId,
+  setPortfolioSnapshot,
+  setPortfolioStatus,
+  setPortfolioError,
+  resetPortfolioState,
+} = portfolioSlice.actions;
+
+export default portfolioSlice.reducer;
+
+export const selectActivePortfolioId = (state: RootState): string =>
+  state.portfolio.activePortfolioId ?? DEFAULT_PORTFOLIO_ID;
+
+export const selectPortfolioSnapshot = (
+  state: RootState,
+  portfolioId?: string,
+): PortfolioSnapshot | null => {
+  const effectiveId = portfolioId ?? selectActivePortfolioId(state);
+  return state.portfolio.snapshots[effectiveId] ?? null;
+};
+
+export const selectPortfolioStatus = (
+  state: RootState,
+  portfolioId?: string,
+): RequestStatus => {
+  const effectiveId = portfolioId ?? selectActivePortfolioId(state);
+  return state.portfolio.statusByPortfolio[effectiveId] ?? 'idle';
+};
+
+export const selectPortfolioError = (
+  state: RootState,
+  portfolioId?: string,
+): string | null => {
+  const effectiveId = portfolioId ?? selectActivePortfolioId(state);
+  return state.portfolio.errorByPortfolio[effectiveId] ?? null;
+};
+
+export const selectPortfolioLastFetchedAt = (
+  state: RootState,
+  portfolioId?: string,
+): number | null => {
+  const effectiveId = portfolioId ?? selectActivePortfolioId(state);
+  return state.portfolio.lastFetchedAt[effectiveId] ?? null;
+};

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,21 @@
+export function getErrorMessage(error: unknown, fallback = 'Ocorreu um erro inesperado.'): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (error && typeof error === 'object') {
+    if ('message' in error && typeof (error as { message?: unknown }).message === 'string') {
+      return (error as { message: string }).message;
+    }
+
+    if ('error' in error && typeof (error as { error?: unknown }).error === 'string') {
+      return (error as { error: string }).error;
+    }
+  }
+
+  return fallback;
+}


### PR DESCRIPTION
## Summary
- add pipeline, dashboard, and portfolio slices with typed hooks and store wiring
- introduce React Query hooks and service helpers for opportunities, dashboards, and portfolios with optimistic updates
- update domain pages and shared styling to show loading/error states driven by new data sources

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cdfb8961dc8326a8ee997fd2b5ce02