### PR TITLE
Validate portfolio selection storage

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,16 +2,26 @@ import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 
 import { MemoryRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { store } from '@/store';
 
 import App from './App';
 
 describe('App', () => {
   it('renderiza o título principal', () => {
+    const queryClient = new QueryClient();
     render(
-      <MemoryRouter>
-        <App />
-      </MemoryRouter>,
+      <Provider store={store}>
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <App />
+          </MemoryRouter>
+        </QueryClientProvider>
+      </Provider>,
     );
     expect(screen.getByRole('heading', { name: /prop-stream/i })).toBeInTheDocument();
+    queryClient.clear();
   });
 });

--- a/src/app/AppShell.test.tsx
+++ b/src/app/AppShell.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import AppShell from './AppShell';
+import portfolioReducer from '@/store/portfolioSlice';
+import pipelineReducer from '@/store/pipelineSlice';
+import dashboardsReducer from '@/store/dashboardsSlice';
+
+const PORTFOLIO_STORAGE_KEY = 'prop-stream:selected-portfolio';
+
+function createTestStore() {
+  return configureStore({
+    reducer: {
+      pipeline: pipelineReducer,
+      dashboards: dashboardsReducer,
+      portfolio: portfolioReducer,
+    },
+  });
+}
+
+describe('AppShell', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('restaura o portfólio padrão quando encontra um ID obsoleto no armazenamento', async () => {
+    window.localStorage.setItem(PORTFOLIO_STORAGE_KEY, 'obsoleto');
+    const store = createTestStore();
+
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/']}>
+          <Routes>
+            <Route path="/" element={<AppShell />}>
+              <Route index element={<div>Início</div>} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      </Provider>,
+    );
+
+    const portfolioSelect = await screen.findByLabelText(/portfólio ativo/i);
+
+    await waitFor(() => {
+      expect(portfolioSelect).toHaveValue('all');
+      expect(window.localStorage.getItem(PORTFOLIO_STORAGE_KEY)).toBe('all');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- validate the persisted portfolio ID against the available options and fall back to the default value when necessary
- guard portfolio updates before writing to localStorage so obsolete IDs do not get re-saved
- add coverage that simulates an outdated stored value and ensures the selector recovers the default portfolio

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_b_68ce057c34d48326bb2a3277873da786