### PR TITLE
Add fallback navigation for domain routes

### DIFF
--- a/src/domains/analise/index.tsx
+++ b/src/domains/analise/index.tsx
@@ -1,5 +1,5 @@
 import { ChangeEvent } from 'react';
-import { NavLink, Outlet, Route, Routes } from 'react-router-dom';
+import { Navigate, NavLink, Outlet, Route, Routes } from 'react-router-dom';
 
 import {
   useDashboardSummaryQuery,
@@ -259,6 +259,7 @@ export default function AnalysisDomain() {
         <Route index element={<AnalysisOverview />} />
         <Route path="modelagem" element={<AnalysisValuation />} />
         <Route path="cenarios" element={<AnalysisScenarios />} />
+        <Route path="*" element={<Navigate to="." replace />} />
       </Route>
     </Routes>
   );

--- a/src/domains/gestao/index.tsx
+++ b/src/domains/gestao/index.tsx
@@ -1,4 +1,4 @@
-import { NavLink, Outlet, Route, Routes } from 'react-router-dom';
+import { Navigate, NavLink, Outlet, Route, Routes } from 'react-router-dom';
 
 import { usePortfolioSnapshotQuery } from '@/hooks/usePortfolioQueries';
 import { useAppSelector } from '@/store/hooks';
@@ -227,6 +227,7 @@ export default function PortfolioDomain() {
         <Route index element={<PortfolioOverview />} />
         <Route path="distribuicao" element={<PortfolioDistribution />} />
         <Route path="indicadores" element={<PortfolioIndicators />} />
+        <Route path="*" element={<Navigate to="." replace />} />
       </Route>
     </Routes>
   );

--- a/src/domains/originacao/index.tsx
+++ b/src/domains/originacao/index.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react';
-import { NavLink, Outlet, Route, Routes } from 'react-router-dom';
+import { Navigate, NavLink, Outlet, Route, Routes } from 'react-router-dom';
 
 import {
   useCreateOpportunityMutation,
@@ -570,6 +570,7 @@ export default function OriginationDomain() {
         <Route index element={<OriginationOverview />} />
         <Route path="pipeline" element={<OriginationPipeline />} />
         <Route path="relatorios" element={<OriginationReports />} />
+        <Route path="*" element={<Navigate to="." replace />} />
       </Route>
     </Routes>
   );


### PR DESCRIPTION
## Summary
- import Navigate into each domain route module
- add splat routes that redirect invalid domain paths to the index view

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_b_68ce07081974832688a408f4870e599b