### PR TITLE
feat: add design system storybook setup

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,0 +1,22 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+
+const config: StorybookConfig = {
+  stories: [
+    '../src/design-system/**/*.mdx',
+    '../src/design-system/**/*.stories.@(ts|tsx)'
+  ],
+  addons: [
+    '@storybook/addon-essentials',
+    '@storybook/addon-interactions',
+    '@storybook/addon-themes'
+  ],
+  framework: {
+    name: '@storybook/react-vite',
+    options: {}
+  },
+  docs: {
+    autodocs: true
+  }
+};
+
+export default config;

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,0 +1,68 @@
+import type { Preview } from '@storybook/react';
+import React from 'react';
+import { DesignSystemProvider, ThemeName } from '../src/design-system';
+import { lightTokens, darkTokens, tokensToCssVariables } from '../src/design-system';
+
+const preview: Preview = {
+  parameters: {
+    backgrounds: {
+      default: 'surface',
+      values: [
+        {
+          name: 'surface',
+          value: lightTokens.colors.surface
+        },
+        {
+          name: 'surface-dark',
+          value: darkTokens.colors.surface
+        }
+      ]
+    },
+    layout: 'fullscreen',
+    options: {
+      storySort: {
+        order: ['Design System', ['Tokens', 'Button', 'Text Input', 'Data Table', 'Bar Chart']]
+      }
+    },
+    docs: {
+      theme: {
+        base: 'light',
+        brandTitle: 'Prop Stream Design System',
+        brandUrl: 'https://storybook.js.org',
+        brandTarget: '_blank',
+        appContentBg: lightTokens.colors.background,
+        appBg: lightTokens.colors.surface
+      }
+    },
+    designTokens: {
+      light: tokensToCssVariables(lightTokens),
+      dark: tokensToCssVariables(darkTokens)
+    }
+  },
+  globalTypes: {
+    theme: {
+      name: 'Theme',
+      description: 'Control the active design theme',
+      defaultValue: 'light',
+      toolbar: {
+        icon: 'circlehollow',
+        items: [
+          { value: 'light', title: 'Claro' },
+          { value: 'dark', title: 'Escuro' }
+        ]
+      }
+    }
+  },
+  decorators: [
+    (Story, context) => {
+      const theme = (context.globals.theme || 'light') as ThemeName;
+      return (
+        <DesignSystemProvider theme={theme}>
+          <Story />
+        </DesignSystemProvider>
+      );
+    }
+  ]
+};
+
+export default preview;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "lint": "eslint .",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run"
   },
@@ -22,6 +24,13 @@
     "react-router-dom": "^6.26.2"
   },
   "devDependencies": {
+    "@storybook/addon-essentials": "^8.3.5",
+    "@storybook/addon-interactions": "^8.3.5",
+    "@storybook/addon-themes": "^8.3.5",
+    "@storybook/blocks": "^8.3.5",
+    "@storybook/react-vite": "^8.3.5",
+    "@storybook/theming": "^8.3.5",
+    "@mdx-js/react": "^3.0.1",
     "@testing-library/jest-dom": "^6.4.6",
     "@testing-library/react": "^16.0.1",
     "@typescript-eslint/eslint-plugin": "^8.11.0",

--- a/src/design-system/components/Button/Button.stories.mdx
+++ b/src/design-system/components/Button/Button.stories.mdx
@@ -1,0 +1,54 @@
+import { Meta, Title, Subtitle, Description, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { Button } from './Button';
+
+<Meta title="Design System/Button" component={Button} />
+
+<Title>Button</Title>
+<Subtitle>Ações chamativas com estilo sólido, contornado ou ghost.</Subtitle>
+<Description>
+  Utilize botões para disparar ações principais ou secundárias. Prefira o variant "solid" para fluxos primários
+  e o "outline" quando existir competição visual. O variant "ghost" é indicado para ações neutras ou com menor
+  hierarquia.
+</Description>
+
+## Exemplos rápidos
+<Canvas>
+  <Story name="Variantes" args={{ children: 'Salvar alterações' }}>
+    {({ args }) => (
+      <div style={{ display: 'flex', gap: 'var(--ds-spacing-3)', flexWrap: 'wrap' }}>
+        <Button {...args} variant="solid" tone="primary" />
+        <Button {...args} variant="outline" tone="primary" />
+        <Button {...args} variant="ghost" tone="primary" />
+      </div>
+    )}
+  </Story>
+</Canvas>
+
+## Estados suportados
+<Canvas>
+  <Story name="Loading e Disabled" args={{ children: 'Processando' }}>
+    {({ args }) => (
+      <div style={{ display: 'flex', gap: 'var(--ds-spacing-3)', flexWrap: 'wrap' }}>
+        <Button {...args} loading />
+        <Button {...args} disabled>Desativado</Button>
+        <Button {...args} tone="danger">Erro crítico</Button>
+      </div>
+    )}
+  </Story>
+</Canvas>
+
+## Tamanhos
+<Canvas>
+  <Story name="Sizes" args={{ children: 'Continuar' }}>
+    {({ args }) => (
+      <div style={{ display: 'flex', gap: 'var(--ds-spacing-3)', flexWrap: 'wrap', alignItems: 'center' }}>
+        <Button {...args} size="sm">Pequeno</Button>
+        <Button {...args} size="md">Médio</Button>
+        <Button {...args} size="lg">Grande</Button>
+      </div>
+    )}
+  </Story>
+</Canvas>
+
+## Props disponíveis
+<ArgsTable of={Button} />

--- a/src/design-system/components/Button/Button.tsx
+++ b/src/design-system/components/Button/Button.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import { useDesignSystem } from '../../theme';
+import { Spinner } from '../_shared/Spinner';
+
+type ButtonVariant = 'solid' | 'outline' | 'ghost';
+type ButtonSize = 'sm' | 'md' | 'lg';
+type ButtonTone = 'primary' | 'neutral' | 'danger';
+
+export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: ButtonVariant;
+  tone?: ButtonTone;
+  size?: ButtonSize;
+  leadingIcon?: ReactNode;
+  trailingIcon?: ReactNode;
+  loading?: boolean;
+};
+
+const sizeTokens: Record<ButtonSize, { paddingX: string; paddingY: string; fontSize: string }> = {
+  sm: {
+    paddingX: 'var(--ds-spacing-3)',
+    paddingY: 'var(--ds-spacing-2)',
+    fontSize: 'var(--ds-typography-font-size-sm)'
+  },
+  md: {
+    paddingX: 'var(--ds-spacing-4)',
+    paddingY: 'var(--ds-spacing-2.5)',
+    fontSize: 'var(--ds-typography-font-size-base)'
+  },
+  lg: {
+    paddingX: 'var(--ds-spacing-5)',
+    paddingY: 'var(--ds-spacing-3)',
+    fontSize: 'var(--ds-typography-font-size-lg)'
+  }
+};
+
+const toneToPaletteKey: Record<ButtonTone, string> = {
+  primary: 'primary',
+  neutral: 'text',
+  danger: 'danger'
+};
+
+const getPaletteColor = (
+  tokens: ReturnType<typeof useDesignSystem>['tokens'],
+  tone: ButtonTone,
+  shade: string
+) => {
+  const palette = tokens.colors[toneToPaletteKey[tone]];
+  if (typeof palette === 'string') {
+    return palette;
+  }
+  return (palette as Record<string, string>)[shade] ?? (palette as Record<string, string>)['500'];
+};
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      children,
+      variant = 'solid',
+      tone = 'primary',
+      size = 'md',
+      leadingIcon,
+      trailingIcon,
+      loading = false,
+      disabled,
+      style,
+      ...props
+    },
+    ref
+  ) => {
+    const { tokens } = useDesignSystem();
+    const [isHovered, setIsHovered] = React.useState(false);
+
+    const baseStyle: React.CSSProperties = {
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: tokens.spacing['2'],
+      borderRadius: tokens.radius.md,
+      borderWidth: 1,
+      borderStyle: 'solid',
+      fontWeight: tokens.typography.fontWeight.semibold,
+      cursor: disabled || loading ? 'not-allowed' : 'pointer',
+      opacity: disabled ? 0.6 : 1,
+      transition:
+        'transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease',
+      textDecoration: 'none',
+      outline: 'none'
+    };
+
+    const sizeStyles = sizeTokens[size];
+
+    const palette = tokens.colors[toneToPaletteKey[tone]];
+    const color500 = getPaletteColor(tokens, tone, '500');
+    const color600 = getPaletteColor(tokens, tone, '600');
+    const color50 = getPaletteColor(tokens, tone, '50');
+
+    const toneForeground =
+      typeof palette === 'string'
+        ? tokens.colors.surface
+        : (palette as Record<string, string>).foreground ?? tokens.colors.surface;
+
+    const variantStyles: Record<ButtonVariant, React.CSSProperties> = {
+      solid: {
+        backgroundColor: color500,
+        color: tone === 'neutral' ? tokens.colors.surface : toneForeground,
+        borderColor: color500
+      },
+      outline: {
+        backgroundColor: 'transparent',
+        color: color600,
+        borderColor: color500
+      },
+      ghost: {
+        backgroundColor: tone === 'neutral' ? tokens.colors.surfaceMuted : color50,
+        color: color600,
+        borderColor: 'transparent'
+      }
+    };
+
+    const hoverStyles: Record<ButtonVariant, React.CSSProperties> = {
+      solid: {
+        backgroundColor: color600,
+        boxShadow: tokens.shadow.sm
+      },
+      outline: {
+        borderColor: color600,
+        color: color600,
+        backgroundColor: tone === 'neutral' ? 'rgba(15,23,42,0.05)' : `${color50}`
+      },
+      ghost: {
+        backgroundColor: tone === 'neutral' ? 'rgba(15,23,42,0.05)' : `${color50}`,
+        color: color600
+      }
+    };
+
+    const finalStyle: React.CSSProperties = {
+      ...baseStyle,
+      paddingInline: sizeStyles.paddingX,
+      paddingBlock: sizeStyles.paddingY,
+      fontSize: sizeStyles.fontSize,
+      ...variantStyles[variant],
+      ...(isHovered && !disabled && !loading ? hoverStyles[variant] : {}),
+      ...style
+    };
+
+    return (
+      <button
+        ref={ref}
+        style={finalStyle}
+        disabled={disabled || loading}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+        onFocus={() => setIsHovered(true)}
+        onBlur={() => setIsHovered(false)}
+        {...props}
+      >
+        {loading ? (
+          <Spinner />
+        ) : (
+          <>
+            {leadingIcon ? <span style={{ display: 'inline-flex' }}>{leadingIcon}</span> : null}
+            <span style={{ whiteSpace: 'nowrap' }}>{children}</span>
+            {trailingIcon ? <span style={{ display: 'inline-flex' }}>{trailingIcon}</span> : null}
+          </>
+        )}
+      </button>
+    );
+  }
+);
+
+Button.displayName = 'Button';

--- a/src/design-system/components/Chart/BarChart.stories.mdx
+++ b/src/design-system/components/Chart/BarChart.stories.mdx
@@ -1,0 +1,40 @@
+import { Meta, Title, Subtitle, Description, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { BarChart } from './BarChart';
+
+const chartData = [
+  { label: 'Janeiro', value: 45 },
+  { label: 'Fevereiro', value: 60 },
+  { label: 'Março', value: 32 },
+  { label: 'Abril', value: 78 }
+];
+
+<Meta title="Design System/Bar Chart" component={BarChart} />
+
+<Title>BarChart</Title>
+<Subtitle>Visualização simples para valores comparativos.</Subtitle>
+<Description>
+  Utilize o gráfico de barras para comparar resultados entre categorias. A função <code>valueFormatter</code> permite
+  formatar números conforme o contexto (percentual, moeda, volume). Prefira até 8 barras para manter a legibilidade.
+</Description>
+
+## Demonstração básica
+<Canvas>
+  <Story name="Default">
+    <BarChart title="Novos leads por mês" description="Baseado nas oportunidades do último trimestre" data={chartData} />
+  </Story>
+</Canvas>
+
+## Estados de carregamento, erro e desativado
+<Canvas>
+  <Story name="Estados">
+    <div style={{ display: 'grid', gap: 'var(--ds-spacing-5)' }}>
+      <BarChart title="Carregando" data={[]} isLoading />
+      <BarChart title="Erro" data={[]} error="Falha ao buscar dados da API." />
+      <BarChart title="Sem dados" data={[]} emptyMessage="Selecione um período para visualizar o desempenho." />
+      <BarChart title="Somente leitura" data={chartData} disabled description="Atualização automática desativada." />
+    </div>
+  </Story>
+</Canvas>
+
+## Props disponíveis
+<ArgsTable of={BarChart} />

--- a/src/design-system/components/Chart/BarChart.tsx
+++ b/src/design-system/components/Chart/BarChart.tsx
@@ -1,0 +1,210 @@
+import React from 'react';
+import type { ReactNode } from 'react';
+import { useDesignSystem } from '../../theme';
+import { Spinner } from '../_shared/Spinner';
+
+export type BarChartDatum = {
+  label: string;
+  value: number;
+  color?: string;
+  description?: ReactNode;
+};
+
+export type BarChartProps = {
+  title?: ReactNode;
+  description?: ReactNode;
+  data: BarChartDatum[];
+  valueFormatter?: (value: number) => string;
+  isLoading?: boolean;
+  error?: ReactNode;
+  emptyMessage?: ReactNode;
+  disabled?: boolean;
+};
+
+const defaultFormatter = (value: number) => Intl.NumberFormat('pt-BR').format(value);
+
+export const BarChart: React.FC<BarChartProps> = ({
+  title,
+  description,
+  data,
+  valueFormatter = defaultFormatter,
+  isLoading = false,
+  error,
+  emptyMessage = 'Sem dados para exibir.',
+  disabled = false
+}) => {
+  const { tokens } = useDesignSystem();
+  const maxValue = Math.max(...data.map((item) => item.value), 0);
+  const palette = tokens.colors.primary;
+  const defaultBarColor =
+    typeof palette === 'string'
+      ? palette
+      : (palette as Record<string, string>)['500'] ?? tokens.colors.text;
+
+  const renderState = () => {
+    if (isLoading) {
+      return (
+        <div
+          style={{
+            display: 'grid',
+            gap: tokens.spacing['3'],
+            paddingTop: tokens.spacing['4']
+          }}
+        >
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div key={index} className="ds-skeleton" style={{ height: '28px' }} />
+          ))}
+        </div>
+      );
+    }
+
+    if (error) {
+      return (
+        <div
+          role="alert"
+          className="ds-card"
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: tokens.spacing['3'],
+            textAlign: 'center'
+          }}
+        >
+          <strong style={{ fontWeight: tokens.typography.fontWeight.semibold }}>Erro ao renderizar o gráfico</strong>
+          <span className="ds-text-muted" style={{ fontSize: tokens.typography.fontSize.sm }}>
+            {error}
+          </span>
+        </div>
+      );
+    }
+
+    if (!data.length) {
+      return (
+        <div
+          className="ds-card"
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: tokens.spacing['2'],
+            textAlign: 'center'
+          }}
+        >
+          <strong style={{ fontWeight: tokens.typography.fontWeight.medium }}>Sem dados</strong>
+          <span className="ds-text-muted" style={{ fontSize: tokens.typography.fontSize.sm }}>
+            {emptyMessage}
+          </span>
+        </div>
+      );
+    }
+
+    return (
+      <div
+        role="img"
+        aria-label={typeof title === 'string' ? title : 'Gráfico de barras'}
+        style={{
+          display: 'grid',
+          gap: tokens.spacing['3'],
+          paddingTop: tokens.spacing['4']
+        }}
+      >
+        {data.map((item) => {
+          const percentage = maxValue === 0 ? 0 : Math.round((item.value / maxValue) * 100);
+          const barColor = item.color ?? defaultBarColor;
+          return (
+            <div key={item.label} style={{ display: 'grid', gap: tokens.spacing['1'] }}>
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'baseline',
+                  fontSize: tokens.typography.fontSize.sm,
+                  color: tokens.colors.text
+                }}
+              >
+                <span>{item.label}</span>
+                <strong style={{ fontWeight: tokens.typography.fontWeight.semibold }}>
+                  {valueFormatter(item.value)}
+                </strong>
+              </div>
+              <div
+                aria-hidden
+                style={{
+                  backgroundColor: tokens.colors.surfaceMuted,
+                  borderRadius: tokens.radius.full,
+                  height: '12px',
+                  overflow: 'hidden',
+                  opacity: disabled ? 0.5 : 1
+                }}
+              >
+                <div
+                  style={{
+                    width: `${percentage}%`,
+                    background: `linear-gradient(90deg, ${barColor}, ${barColor})`,
+                    borderRadius: tokens.radius.full,
+                    height: '100%',
+                    transition: 'width 0.4s ease'
+                  }}
+                />
+              </div>
+              {item.description ? (
+                <span className="ds-text-muted" style={{ fontSize: tokens.typography.fontSize.xs }}>
+                  {item.description}
+                </span>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
+  return (
+    <section
+      aria-busy={isLoading}
+      aria-disabled={disabled}
+      style={{
+        display: 'grid',
+        gap: tokens.spacing['2'],
+        padding: tokens.spacing['5'],
+        borderRadius: tokens.radius.lg,
+        border: `1px solid ${tokens.colors.border}`,
+        boxShadow: tokens.shadow.sm,
+        backgroundColor: tokens.colors.surface,
+        opacity: disabled ? 0.6 : 1,
+        minWidth: 0
+      }}
+    >
+      {title ? (
+        <header style={{ display: 'grid', gap: tokens.spacing['1'] }}>
+          <h3
+            style={{
+              margin: 0,
+              fontSize: tokens.typography.fontSize.lg,
+              fontWeight: tokens.typography.fontWeight.semibold,
+              color: tokens.colors.text
+            }}
+          >
+            {title}
+          </h3>
+          {description ? (
+            <p
+              style={{
+                margin: 0,
+                fontSize: tokens.typography.fontSize.sm,
+                color: tokens.colors.textMuted
+              }}
+            >
+              {description}
+            </p>
+          ) : null}
+        </header>
+      ) : null}
+      {isLoading ? (
+        <div style={{ display: 'flex', justifyContent: 'center', padding: tokens.spacing['4'] }}>
+          <Spinner />
+        </div>
+      ) : null}
+      {renderState()}
+    </section>
+  );
+};

--- a/src/design-system/components/Input/TextInput.stories.mdx
+++ b/src/design-system/components/Input/TextInput.stories.mdx
@@ -1,0 +1,40 @@
+import { Meta, Title, Subtitle, Description, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { TextInput } from './TextInput';
+
+<Meta title="Design System/Text Input" component={TextInput} />
+
+<Title>TextInput</Title>
+<Subtitle>Campo de entrada simples com suporte a descrição, ícones e estados de validação.</Subtitle>
+<Description>
+  Priorize o uso do label visível e utilize os estados para comunicar feedback claro ao usuário. O estado
+  "error" deve trazer uma mensagem objetiva. Combine "description" com "hint" para fornecer instruções
+  complementares.
+</Description>
+
+## Uso padrão
+<Canvas>
+  <Story name="Default" args={{ label: 'E-mail', placeholder: 'nome@empresa.com' }}>
+    {({ args }) => <TextInput {...args} />}
+  </Story>
+</Canvas>
+
+## Estados de carregamento e desativado
+<Canvas>
+  <Story name="Estados" args={{ label: 'CPF', placeholder: '000.000.000-00' }}>
+    {({ args }) => (
+      <div style={{ display: 'grid', gap: 'var(--ds-spacing-4)' }}>
+        <TextInput {...args} loading description="Validando documento" />
+        <TextInput {...args} disabled hint="Disponível apenas para administradores" />
+        <TextInput
+          {...args}
+          state="error"
+          error="CPF inválido. Confira os números informados."
+          description="Insira apenas dígitos, sem caracteres especiais."
+        />
+      </div>
+    )}
+  </Story>
+</Canvas>
+
+## Props disponíveis
+<ArgsTable of={TextInput} />

--- a/src/design-system/components/Input/TextInput.tsx
+++ b/src/design-system/components/Input/TextInput.tsx
@@ -1,0 +1,220 @@
+import React, { useId, useState } from 'react';
+import type { InputHTMLAttributes, ReactNode } from 'react';
+import { useDesignSystem } from '../../theme';
+import { Spinner } from '../_shared/Spinner';
+
+type TextInputState = 'default' | 'error' | 'success';
+
+export type TextInputProps = InputHTMLAttributes<HTMLInputElement> & {
+  label?: ReactNode;
+  description?: ReactNode;
+  error?: ReactNode;
+  hint?: ReactNode;
+  leadingIcon?: ReactNode;
+  trailingIcon?: ReactNode;
+  loading?: boolean;
+  state?: TextInputState;
+};
+
+const stateColorKey: Record<TextInputState, keyof ReturnType<typeof useDesignSystem>['tokens']['colors']> = {
+  default: 'border',
+  error: 'danger',
+  success: 'success'
+};
+
+export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
+  (
+    {
+      label,
+      description,
+      error,
+      hint,
+      leadingIcon,
+      trailingIcon,
+      loading = false,
+      disabled,
+      state = 'default',
+      style,
+      id,
+      ...props
+    },
+    ref
+  ) => {
+    const generatedId = useId();
+    const inputId = id ?? generatedId;
+    const descriptionId = description ? `${inputId}-description` : undefined;
+    const errorId = error ? `${inputId}-error` : undefined;
+
+    const { tokens } = useDesignSystem();
+    const paletteKey = stateColorKey[state];
+    const palette = tokens.colors[paletteKey];
+    const focusPaletteKey = state === 'default' ? 'primary' : paletteKey;
+    const focusPalette = tokens.colors[focusPaletteKey];
+
+    const getPaletteShade = (value: unknown, shade: string, fallback: string) => {
+      if (typeof value === 'string') {
+        return value;
+      }
+      if (value && typeof value === 'object' && shade in (value as Record<string, string>)) {
+        return (value as Record<string, string>)[shade];
+      }
+      return fallback;
+    };
+
+    const focusColor = getPaletteShade(focusPalette, '500', tokens.colors.border);
+    const baseBorderColor =
+      state === 'default'
+        ? tokens.colors.border
+        : getPaletteShade(palette, '400', tokens.colors.border);
+    const focusRingColor =
+      state === 'error'
+        ? 'rgba(244,63,94,0.25)'
+        : state === 'success'
+          ? 'rgba(16,185,129,0.25)'
+          : 'rgba(59,130,246,0.18)';
+
+    const [isFocused, setIsFocused] = useState(false);
+
+    const containerStyle: React.CSSProperties = {
+      position: 'relative',
+      display: 'flex',
+      alignItems: 'center',
+      borderRadius: tokens.radius.md,
+      border: `1px solid ${isFocused ? focusColor : baseBorderColor}`,
+      backgroundColor: disabled ? tokens.colors.surfaceMuted : tokens.colors.surface,
+      transition: 'border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease',
+      boxShadow: isFocused ? `0 0 0 4px ${focusRingColor}` : 'none'
+    };
+
+    return (
+      <div
+        style={{
+          display: 'grid',
+          gap: tokens.spacing['2'],
+          width: '100%',
+          ...style
+        }}
+      >
+        {label ? (
+          <label
+            htmlFor={inputId}
+            style={{
+              fontSize: tokens.typography.fontSize.sm,
+              fontWeight: tokens.typography.fontWeight.medium,
+              color: tokens.colors.text
+            }}
+          >
+            {label}
+          </label>
+        ) : null}
+
+        {description ? (
+          <span
+            id={descriptionId}
+            style={{
+              fontSize: tokens.typography.fontSize.sm,
+              color: tokens.colors.textMuted
+            }}
+          >
+            {description}
+          </span>
+        ) : null}
+
+        <div style={containerStyle} data-disabled={disabled || loading}>
+          {leadingIcon ? (
+            <span
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                paddingInline: tokens.spacing['3'],
+                color: tokens.colors.textMuted
+              }}
+            >
+              {leadingIcon}
+            </span>
+          ) : null}
+
+          <input
+            ref={ref}
+            id={inputId}
+            disabled={disabled || loading}
+            aria-describedby={[descriptionId, errorId].filter(Boolean).join(' ') || undefined}
+            aria-invalid={state === 'error'}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
+            style={{
+              flex: 1,
+              border: 'none',
+              outline: 'none',
+              background: 'transparent',
+              paddingBlock: tokens.spacing['2.5'],
+              paddingInlineStart: leadingIcon ? tokens.spacing['2'] : tokens.spacing['3'],
+              paddingInlineEnd: trailingIcon ? tokens.spacing['2'] : tokens.spacing['3'],
+              fontSize: tokens.typography.fontSize.base,
+              color: tokens.colors.text,
+              caretColor: focusColor
+            }}
+            {...props}
+          />
+
+          {loading ? (
+            <span
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                paddingInline: tokens.spacing['3'],
+                color: tokens.colors.textMuted
+              }}
+            >
+              <Spinner size={16} />
+            </span>
+          ) : null}
+
+          {trailingIcon && !loading ? (
+            <span
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                paddingInline: tokens.spacing['3'],
+                color: tokens.colors.textMuted
+              }}
+            >
+              {trailingIcon}
+            </span>
+          ) : null}
+        </div>
+
+        {hint && state !== 'error' ? (
+          <span
+            style={{
+              fontSize: tokens.typography.fontSize.xs,
+              color: tokens.colors.textMuted
+            }}
+          >
+            {hint}
+          </span>
+        ) : null}
+
+        {error && state === 'error' ? (
+          <span
+            id={errorId}
+            role="alert"
+            style={{
+              fontSize: tokens.typography.fontSize.sm,
+              color:
+                typeof tokens.colors.danger === 'string'
+                  ? tokens.colors.danger
+                  : (tokens.colors.danger as Record<string, string>)['500']
+            }}
+          >
+            {error}
+          </span>
+        ) : null}
+      </div>
+    );
+  }
+);
+
+TextInput.displayName = 'TextInput';

--- a/src/design-system/components/Table/DataTable.stories.mdx
+++ b/src/design-system/components/Table/DataTable.stories.mdx
@@ -1,0 +1,45 @@
+import { Meta, Title, Subtitle, Description, Canvas, Story, ArgsTable } from '@storybook/blocks';
+import { DataTable } from './DataTable';
+
+const sampleColumns = [
+  { key: 'name', header: 'Nome' },
+  { key: 'status', header: 'Status', align: 'center' },
+  { key: 'leads', header: 'Leads', align: 'right' }
+];
+
+const sampleRows = [
+  { id: 1, name: 'Campanha A', status: 'Ativa', leads: 120 },
+  { id: 2, name: 'Campanha B', status: 'Pausada', leads: 45 },
+  { id: 3, name: 'Campanha C', status: 'Rascunho', leads: 0 }
+];
+
+<Meta title="Design System/Data Table" component={DataTable} />
+
+<Title>DataTable</Title>
+<Subtitle>Tabelas responsivas com mensagens para estados especiais.</Subtitle>
+<Description>
+  Use a tabela para coleções com até algumas dezenas de linhas. Ative o callback <code>onRowClick</code> para ações
+  rápidas e utilize mensagens customizadas nos estados de carregamento, vazia ou erro para guiar o usuário.
+</Description>
+
+## Tabela padrão
+<Canvas>
+  <Story name="Default">
+    <DataTable columns={sampleColumns} rows={sampleRows} caption="Desempenho das campanhas" />
+  </Story>
+</Canvas>
+
+## Estados principais
+<Canvas>
+  <Story name="Loading, Empty, Error e Disabled">
+    <div style={{ display: 'grid', gap: 'var(--ds-spacing-5)' }}>
+      <DataTable columns={sampleColumns} rows={[]} isLoading />
+      <DataTable columns={sampleColumns} rows={[]} emptyMessage="Inclua filtros diferentes para visualizar resultados." />
+      <DataTable columns={sampleColumns} rows={[]} error="Servidor indisponível. Tente novamente mais tarde." />
+      <DataTable columns={sampleColumns} rows={sampleRows} disabled caption="Interação temporariamente bloqueada" />
+    </div>
+  </Story>
+</Canvas>
+
+## Props disponíveis
+<ArgsTable of={DataTable} />

--- a/src/design-system/components/Table/DataTable.tsx
+++ b/src/design-system/components/Table/DataTable.tsx
@@ -1,0 +1,226 @@
+import React from 'react';
+import type { ReactNode } from 'react';
+import { useDesignSystem } from '../../theme';
+
+export type DataTableColumn = {
+  key: string;
+  header: ReactNode;
+  align?: 'left' | 'center' | 'right';
+  width?: string;
+};
+
+export type DataTableRow = Record<string, ReactNode> & {
+  id?: string | number;
+};
+
+export type DataTableProps = {
+  columns: DataTableColumn[];
+  rows: DataTableRow[];
+  isLoading?: boolean;
+  error?: ReactNode;
+  emptyMessage?: ReactNode;
+  onRowClick?: (row: DataTableRow) => void;
+  caption?: ReactNode;
+  disabled?: boolean;
+};
+
+const alignToJustify: Record<'left' | 'center' | 'right', string> = {
+  left: 'flex-start',
+  center: 'center',
+  right: 'flex-end'
+};
+
+const SkeletonRow: React.FC<{ columns: DataTableColumn[] }> = ({ columns }) => (
+  <tr>
+    {columns.map((column) => (
+      <td key={column.key} style={{ padding: 'var(--ds-spacing-3) var(--ds-spacing-4)' }}>
+        <div className="ds-skeleton" style={{ height: '12px', width: '70%' }} />
+      </td>
+    ))}
+  </tr>
+);
+
+export const DataTable: React.FC<DataTableProps> = ({
+  columns,
+  rows,
+  isLoading = false,
+  error,
+  emptyMessage = 'Nenhum dado disponível no momento.',
+  onRowClick,
+  caption,
+  disabled = false
+}) => {
+  const { tokens } = useDesignSystem();
+
+  const renderContent = () => {
+    if (isLoading) {
+      return (
+        <tbody>
+          {Array.from({ length: 3 }).map((_, index) => (
+            <SkeletonRow key={`skeleton-${index}`} columns={columns} />
+          ))}
+        </tbody>
+      );
+    }
+
+    if (error) {
+      return (
+        <tbody>
+          <tr>
+            <td colSpan={columns.length} style={{ padding: tokens.spacing['6'] }}>
+              <div
+                role="alert"
+                className="ds-card"
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  textAlign: 'center',
+                  gap: tokens.spacing['3']
+                }}
+              >
+                <strong style={{ fontWeight: tokens.typography.fontWeight.semibold }}>Erro ao carregar dados</strong>
+                <span className="ds-text-muted" style={{ fontSize: tokens.typography.fontSize.sm }}>
+                  {error}
+                </span>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      );
+    }
+
+    if (!rows.length) {
+      return (
+        <tbody>
+          <tr>
+            <td colSpan={columns.length} style={{ padding: tokens.spacing['6'] }}>
+              <div
+                className="ds-card"
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  textAlign: 'center',
+                  gap: tokens.spacing['3']
+                }}
+              >
+                <strong style={{ fontWeight: tokens.typography.fontWeight.medium }}>Nenhum registro encontrado</strong>
+                <span className="ds-text-muted" style={{ fontSize: tokens.typography.fontSize.sm }}>
+                  {emptyMessage}
+                </span>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      );
+    }
+
+    return (
+      <tbody>
+        {rows.map((row, index) => {
+          const rowKey = row.id ?? `row-${index}`;
+          const isClickable = Boolean(onRowClick) && !disabled;
+          return (
+            <tr
+              key={rowKey}
+              onClick={() => {
+                if (!onRowClick || disabled) return;
+                onRowClick(row);
+              }}
+              style={{
+                cursor: isClickable ? 'pointer' : 'default',
+                opacity: disabled ? 0.6 : 1,
+                transition: 'background-color 0.2s ease'
+              }}
+              onMouseEnter={(event) => {
+                if (!isClickable) return;
+                event.currentTarget.style.backgroundColor = tokens.colors.surfaceMuted;
+              }}
+              onMouseLeave={(event) => {
+                event.currentTarget.style.backgroundColor = 'transparent';
+              }}
+            >
+              {columns.map((column) => (
+                <td
+                  key={column.key}
+                  style={{
+                    padding: `${tokens.spacing['3']} ${tokens.spacing['4']}`,
+                    borderTop: `1px solid ${tokens.colors.border}`,
+                    fontSize: tokens.typography.fontSize.sm,
+                    color: tokens.colors.text,
+                    opacity: disabled ? 0.75 : 1
+                  }}
+                >
+                  <div
+                    style={{
+                      display: 'flex',
+                      justifyContent: alignToJustify[column.align ?? 'left'],
+                      width: '100%'
+                    }}
+                  >
+                    {row[column.key] ?? '—'}
+                  </div>
+                </td>
+              ))}
+            </tr>
+          );
+        })}
+      </tbody>
+    );
+  };
+
+  return (
+    <div
+      style={{
+        width: '100%',
+        overflowX: 'auto',
+        borderRadius: tokens.radius.lg,
+        border: `1px solid ${tokens.colors.border}`,
+        boxShadow: tokens.shadow.sm,
+        backgroundColor: tokens.colors.surface,
+        opacity: disabled ? 0.7 : 1
+      }}
+    >
+      <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: '600px' }}>
+        {caption ? (
+          <caption
+            style={{
+              textAlign: 'left',
+              padding: `${tokens.spacing['3']} ${tokens.spacing['4']}`,
+              fontSize: tokens.typography.fontSize.sm,
+              color: tokens.colors.textMuted
+            }}
+          >
+            {caption}
+          </caption>
+        ) : null}
+        <thead>
+          <tr>
+            {columns.map((column) => (
+              <th
+                key={column.key}
+                scope="col"
+                style={{
+                  textAlign: column.align ?? 'left',
+                  fontSize: tokens.typography.fontSize.xs,
+                  letterSpacing: '0.08em',
+                  textTransform: 'uppercase',
+                  fontWeight: tokens.typography.fontWeight.semibold,
+                  color: tokens.colors.textMuted,
+                  padding: `${tokens.spacing['3']} ${tokens.spacing['4']}`,
+                  backgroundColor: tokens.colors.surfaceMuted,
+                  borderBottom: `1px solid ${tokens.colors.border}`,
+                  width: column.width
+                }}
+              >
+                {column.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        {renderContent()}
+      </table>
+    </div>
+  );
+};

--- a/src/design-system/components/_shared/Spinner.tsx
+++ b/src/design-system/components/_shared/Spinner.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+type SpinnerProps = {
+  size?: number;
+  color?: string;
+};
+
+export const Spinner: React.FC<SpinnerProps> = ({ size = 18, color = 'currentColor' }) => (
+  <span
+    aria-hidden
+    className="ds-spinner"
+    style={{
+      width: `${size}px`,
+      height: `${size}px`,
+      color
+    }}
+  />
+);
+

--- a/src/design-system/index.ts
+++ b/src/design-system/index.ts
@@ -1,0 +1,9 @@
+export * from './theme';
+export { Button } from './components/Button/Button';
+export type { ButtonProps } from './components/Button/Button';
+export { TextInput } from './components/Input/TextInput';
+export type { TextInputProps } from './components/Input/TextInput';
+export { DataTable } from './components/Table/DataTable';
+export type { DataTableProps, DataTableColumn, DataTableRow } from './components/Table/DataTable';
+export { BarChart } from './components/Chart/BarChart';
+export type { BarChartProps, BarChartDatum } from './components/Chart/BarChart';

--- a/src/design-system/styles.css
+++ b/src/design-system/styles.css
@@ -1,0 +1,63 @@
+:root,
+[data-ds-theme] {
+  color-scheme: light dark;
+}
+
+.ds-provider {
+  min-height: 100%;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.ds-provider *,
+.ds-provider *::before,
+.ds-provider *::after {
+  box-sizing: border-box;
+}
+
+.ds-text-muted {
+  color: var(--ds-colors-text-muted);
+}
+
+.ds-card {
+  background-color: var(--ds-colors-surface);
+  border: 1px solid var(--ds-colors-border);
+  border-radius: var(--ds-radius-lg);
+  box-shadow: var(--ds-shadow-sm);
+  padding: var(--ds-spacing-5);
+}
+
+.ds-spinner {
+  width: 1.125rem;
+  height: 1.125rem;
+  border-radius: 9999px;
+  border: 2px solid transparent;
+  border-top-color: currentColor;
+  animation: ds-spin 0.8s linear infinite;
+}
+
+.ds-skeleton {
+  background: linear-gradient(
+    90deg,
+    rgba(148, 163, 184, 0.08) 25%,
+    rgba(148, 163, 184, 0.24) 37%,
+    rgba(148, 163, 184, 0.08) 63%
+  );
+  background-size: 400% 100%;
+  animation: ds-skeleton 1.4s ease infinite;
+  border-radius: var(--ds-radius-sm);
+}
+
+@keyframes ds-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes ds-skeleton {
+  0% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0 50%;
+  }
+}

--- a/src/design-system/theme/DesignSystemProvider.tsx
+++ b/src/design-system/theme/DesignSystemProvider.tsx
@@ -1,0 +1,67 @@
+import React, { useMemo, useState } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
+import { ThemeName, tokensByTheme } from './tokens';
+import { tokensToCssVariables } from './css';
+import '../styles.css';
+import { DesignSystemContext, type DesignSystemContextValue } from './context';
+
+export type DesignSystemProviderProps = {
+  children: ReactNode;
+  theme?: ThemeName;
+  initialTheme?: ThemeName;
+  style?: CSSProperties;
+  className?: string;
+  onThemeChange?: (theme: ThemeName) => void;
+};
+
+export const DesignSystemProvider: React.FC<DesignSystemProviderProps> = ({
+  children,
+  theme: themeProp,
+  initialTheme = 'light',
+  style,
+  className,
+  onThemeChange
+}) => {
+  const [uncontrolledTheme, setUncontrolledTheme] = useState<ThemeName>(initialTheme);
+
+  const theme = themeProp ?? uncontrolledTheme;
+  const tokens = useMemo(() => tokensByTheme[theme], [theme]);
+
+  const value = useMemo<DesignSystemContextValue>(() => {
+    const setTheme = (nextTheme: ThemeName) => {
+      if (!themeProp) {
+        setUncontrolledTheme(nextTheme);
+      }
+      onThemeChange?.(nextTheme);
+    };
+
+    const toggleTheme = () => {
+      setTheme(theme === 'light' ? 'dark' : 'light');
+    };
+
+    return {
+      theme,
+      tokens,
+      setTheme,
+      toggleTheme
+    };
+  }, [theme, tokens, themeProp, onThemeChange]);
+
+  const cssVariables = useMemo(() => tokensToCssVariables(tokens), [tokens]);
+
+  const mergedStyle = useMemo<React.CSSProperties>(() => ({
+    ...(cssVariables as React.CSSProperties),
+    ...style,
+    backgroundColor: cssVariables['--ds-colors-background'],
+    color: cssVariables['--ds-colors-text'],
+    fontFamily: cssVariables['--ds-typography-font-family-sans']
+  }), [cssVariables, style]);
+
+  return (
+    <DesignSystemContext.Provider value={value}>
+      <div data-ds-theme={theme} className={`ds-provider${className ? ` ${className}` : ''}`} style={mergedStyle}>
+        {children}
+      </div>
+    </DesignSystemContext.Provider>
+  );
+};

--- a/src/design-system/theme/context.ts
+++ b/src/design-system/theme/context.ts
@@ -1,0 +1,22 @@
+import { createContext, useContext } from 'react';
+import type { DesignTokens, ThemeName } from './tokens';
+
+type DesignSystemContextValue = {
+  theme: ThemeName;
+  tokens: DesignTokens;
+  setTheme: (theme: ThemeName) => void;
+  toggleTheme: () => void;
+};
+
+export const DesignSystemContext = createContext<DesignSystemContextValue | undefined>(undefined);
+
+export const useDesignSystem = (): DesignSystemContextValue => {
+  const context = useContext(DesignSystemContext);
+  if (!context) {
+    throw new Error('useDesignSystem must be used inside a DesignSystemProvider');
+  }
+
+  return context;
+};
+
+export type { DesignSystemContextValue };

--- a/src/design-system/theme/css.ts
+++ b/src/design-system/theme/css.ts
@@ -1,0 +1,30 @@
+import type { DesignTokens, NestedTokenRecord } from './tokens';
+
+const formatTokenName = (segment: string) =>
+  segment
+    .replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`)
+    .replace(/\./g, '-')
+    .toLowerCase();
+
+const walkTokens = (
+  tokens: NestedTokenRecord,
+  path: string[],
+  target: Record<string, string>
+) => {
+  Object.entries(tokens).forEach(([key, value]) => {
+    const nextPath = [...path, formatTokenName(key)];
+    if (typeof value === 'string' || typeof value === 'number') {
+      const cssVariableName = `--${nextPath.join('-')}`;
+      target[cssVariableName] = `${value}`;
+    } else if (typeof value === 'object' && value !== null) {
+      walkTokens(value, nextPath, target);
+    }
+  });
+};
+
+export const tokensToCssVariables = (tokens: DesignTokens): Record<string, string> => {
+  const cssVariableMap: Record<string, string> = {};
+  walkTokens(tokens as NestedTokenRecord, ['ds'], cssVariableMap);
+  return cssVariableMap;
+};
+

--- a/src/design-system/theme/index.ts
+++ b/src/design-system/theme/index.ts
@@ -1,0 +1,4 @@
+export * from './DesignSystemProvider';
+export * from './context';
+export * from './tokens';
+export { tokensToCssVariables } from './css';

--- a/src/design-system/theme/tokens.ts
+++ b/src/design-system/theme/tokens.ts
@@ -1,0 +1,235 @@
+export type ThemeName = 'light' | 'dark';
+
+type TokenLeaf = string | number;
+
+export type NestedTokenRecord = {
+  [key: string]: TokenLeaf | NestedTokenRecord;
+};
+
+export type DesignTokens = {
+  colors: NestedTokenRecord & {
+    background: string;
+    surface: string;
+    surfaceMuted: string;
+    border: string;
+    text: string;
+    textMuted: string;
+    primary: NestedTokenRecord & {
+      foreground: string;
+    };
+    success: NestedTokenRecord & {
+      foreground: string;
+    };
+    warning: NestedTokenRecord & {
+      foreground: string;
+    };
+    danger: NestedTokenRecord & {
+      foreground: string;
+    };
+  };
+  spacing: Record<string, string>;
+  typography: {
+    fontFamily: {
+      sans: string;
+      mono: string;
+    };
+    fontSize: Record<string, string>;
+    lineHeight: Record<string, string>;
+    fontWeight: Record<string, number>;
+  };
+  radius: Record<string, string>;
+  shadow: Record<string, string>;
+};
+
+const spacingScale: Record<string, string> = {
+  px: '1px',
+  '0': '0rem',
+  '0.5': '0.125rem',
+  '1': '0.25rem',
+  '1.5': '0.375rem',
+  '2': '0.5rem',
+  '2.5': '0.625rem',
+  '3': '0.75rem',
+  '3.5': '0.875rem',
+  '4': '1rem',
+  '5': '1.25rem',
+  '6': '1.5rem',
+  '8': '2rem',
+  '10': '2.5rem',
+  '12': '3rem'
+};
+
+const typography = {
+  fontFamily: {
+    sans: "'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif",
+    mono: "'IBM Plex Mono', 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace"
+  },
+  fontSize: {
+    xs: '0.75rem',
+    sm: '0.875rem',
+    base: '1rem',
+    lg: '1.125rem',
+    xl: '1.25rem',
+    '2xl': '1.5rem',
+    '3xl': '1.875rem'
+  },
+  lineHeight: {
+    tight: '1.2',
+    snug: '1.35',
+    normal: '1.5',
+    relaxed: '1.7'
+  },
+  fontWeight: {
+    light: 300,
+    normal: 400,
+    medium: 500,
+    semibold: 600,
+    bold: 700
+  }
+};
+
+const radius = {
+  none: '0px',
+  sm: '0.25rem',
+  md: '0.5rem',
+  lg: '0.75rem',
+  xl: '1rem',
+  full: '9999px'
+};
+
+const shadow = {
+  sm: '0 1px 2px 0 rgba(15, 23, 42, 0.07)',
+  md: '0 4px 12px rgba(15, 23, 42, 0.12)',
+  lg: '0 20px 45px rgba(15, 23, 42, 0.18)'
+};
+
+const tailwindPalette = {
+  slate: {
+    50: '#f8fafc',
+    100: '#f1f5f9',
+    200: '#e2e8f0',
+    300: '#cbd5f5',
+    400: '#94a3b8',
+    500: '#64748b',
+    600: '#475569',
+    700: '#334155',
+    800: '#1e293b',
+    900: '#0f172a'
+  },
+  blue: {
+    50: '#eff6ff',
+    100: '#dbeafe',
+    200: '#bfdbfe',
+    300: '#93c5fd',
+    400: '#60a5fa',
+    500: '#3b82f6',
+    600: '#2563eb',
+    700: '#1d4ed8',
+    800: '#1e40af',
+    900: '#1e3a8a'
+  },
+  emerald: {
+    50: '#ecfdf5',
+    100: '#d1fae5',
+    200: '#a7f3d0',
+    300: '#6ee7b7',
+    400: '#34d399',
+    500: '#10b981',
+    600: '#059669',
+    700: '#047857',
+    800: '#065f46',
+    900: '#064e3b'
+  },
+  amber: {
+    50: '#fffbeb',
+    100: '#fef3c7',
+    200: '#fde68a',
+    300: '#fcd34d',
+    400: '#fbbf24',
+    500: '#f59e0b',
+    600: '#d97706',
+    700: '#b45309',
+    800: '#92400e',
+    900: '#78350f'
+  },
+  rose: {
+    50: '#fff1f2',
+    100: '#ffe4e6',
+    200: '#fecdd3',
+    300: '#fda4af',
+    400: '#fb7185',
+    500: '#f43f5e',
+    600: '#e11d48',
+    700: '#be123c',
+    800: '#9f1239',
+    900: '#881337'
+  }
+};
+
+export const lightTokens: DesignTokens = {
+  colors: {
+    background: tailwindPalette.slate[50],
+    surface: '#ffffff',
+    surfaceMuted: tailwindPalette.slate[100],
+    border: tailwindPalette.slate[200],
+    text: tailwindPalette.slate[900],
+    textMuted: tailwindPalette.slate[500],
+    primary: {
+      ...tailwindPalette.blue,
+      foreground: '#ffffff'
+    },
+    success: {
+      ...tailwindPalette.emerald,
+      foreground: '#ffffff'
+    },
+    warning: {
+      ...tailwindPalette.amber,
+      foreground: tailwindPalette.slate[900]
+    },
+    danger: {
+      ...tailwindPalette.rose,
+      foreground: '#ffffff'
+    }
+  },
+  spacing: spacingScale,
+  typography,
+  radius,
+  shadow
+};
+
+export const darkTokens: DesignTokens = {
+  colors: {
+    background: tailwindPalette.slate[900],
+    surface: tailwindPalette.slate[800],
+    surfaceMuted: tailwindPalette.slate[700],
+    border: 'rgba(148, 163, 184, 0.25)',
+    text: '#f8fafc',
+    textMuted: tailwindPalette.slate[300],
+    primary: {
+      ...tailwindPalette.blue,
+      foreground: '#f8fafc'
+    },
+    success: {
+      ...tailwindPalette.emerald,
+      foreground: '#f8fafc'
+    },
+    warning: {
+      ...tailwindPalette.amber,
+      foreground: tailwindPalette.slate[900]
+    },
+    danger: {
+      ...tailwindPalette.rose,
+      foreground: '#f8fafc'
+    }
+  },
+  spacing: spacingScale,
+  typography,
+  radius,
+  shadow
+};
+
+export const tokensByTheme: Record<ThemeName, DesignTokens> = {
+  light: lightTokens,
+  dark: darkTokens
+};
+

--- a/src/design-system/tokens/DesignTokens.stories.mdx
+++ b/src/design-system/tokens/DesignTokens.stories.mdx
@@ -1,0 +1,24 @@
+import { Meta, Title, Subtitle, Description } from '@storybook/blocks';
+import { lightTokens, darkTokens } from '../index';
+import { ColorsTokenGrid, TypographyTokenGrid, SpacingTokenGrid } from './TokenGrid';
+
+<Meta title="Design System/Tokens" />
+
+<Title>Tokens de estilo</Title>
+<Subtitle>Guia rápido de cores, tipografia e espaçamentos inspirados no Tailwind.</Subtitle>
+<Description>
+  Os tokens são expostos como variáveis CSS e objetos JavaScript. Utilize-os para manter consistência visual
+  e simplificar a adoção de tema claro/escuro.
+</Description>
+
+## Paleta de cores clara
+<ColorsTokenGrid theme="light" />
+
+## Paleta de cores escura
+<ColorsTokenGrid theme="dark" />
+
+## Tipografia
+<TypographyTokenGrid tokens={lightTokens} />
+
+## Espaçamentos
+<SpacingTokenGrid tokens={lightTokens} />

--- a/src/design-system/tokens/TokenGrid.tsx
+++ b/src/design-system/tokens/TokenGrid.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import type { ReactNode } from 'react';
+import { lightTokens, darkTokens, DesignTokens } from '../theme';
+
+type TokenGridProps = {
+  title: string;
+  tokens: Record<string, string | number>;
+  renderPreview?: (value: string | number, name: string) => ReactNode;
+};
+
+const normalizeEntries = (tokens: Record<string, string | number>) =>
+  Object.entries(tokens).map(([name, value]) => ({ name, value }));
+
+export const TokenGrid: React.FC<TokenGridProps> = ({ title, tokens, renderPreview }) => (
+  <div style={{ marginBlock: 'var(--ds-spacing-6)' }}>
+    <h3
+      style={{
+        marginBottom: 'var(--ds-spacing-3)',
+        fontSize: 'var(--ds-typography-font-size-lg)',
+        fontWeight: 600
+      }}
+    >
+      {title}
+    </h3>
+    <div
+      style={{
+        display: 'grid',
+        gap: 'var(--ds-spacing-3)',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))'
+      }}
+    >
+      {normalizeEntries(tokens).map(({ name, value }) => (
+        <div
+          key={name}
+          className="ds-card"
+          style={{
+            display: 'grid',
+            gap: 'var(--ds-spacing-2)' 
+          }}
+        >
+          {renderPreview ? (
+            <div>{renderPreview(value, name)}</div>
+          ) : null}
+          <div>
+            <strong style={{ display: 'block', marginBottom: 'var(--ds-spacing-1)' }}>{name}</strong>
+            <code
+              style={{
+                fontFamily: 'var(--ds-typography-font-family-mono)',
+                fontSize: 'var(--ds-typography-font-size-xs)'
+              }}
+            >
+              {String(value)}
+            </code>
+          </div>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+export const ColorsTokenGrid: React.FC<{ theme?: 'light' | 'dark' }> = ({ theme = 'light' }) => {
+  const palette = theme === 'dark' ? darkTokens.colors : lightTokens.colors;
+  const swatches = Object.entries(palette).filter(([, value]) => typeof value !== 'string');
+
+  return (
+    <div style={{ display: 'grid', gap: 'var(--ds-spacing-6)' }}>
+      {swatches.map(([name, value]) => (
+        <TokenGrid
+          key={name}
+          title={name}
+          tokens={value as Record<string, string>}
+          renderPreview={(tokenValue) => (
+            <div
+              style={{
+                height: '48px',
+                borderRadius: 'var(--ds-radius-md)',
+                background: String(tokenValue),
+                border: '1px solid rgba(15,23,42,0.12)'
+              }}
+            />
+          )}
+        />
+      ))}
+    </div>
+  );
+};
+
+export const TypographyTokenGrid: React.FC<{ tokens?: DesignTokens }> = ({ tokens = lightTokens }) => (
+  <div style={{ display: 'grid', gap: 'var(--ds-spacing-3)' }}>
+    <TokenGrid title="Fontes" tokens={tokens.typography.fontFamily} />
+    <TokenGrid
+      title="Tamanhos"
+      tokens={tokens.typography.fontSize}
+      renderPreview={(value) => (
+        <span style={{ fontSize: String(value), display: 'block' }}>Ag 18 {value}</span>
+      )}
+    />
+    <TokenGrid title="Alturas de linha" tokens={tokens.typography.lineHeight} />
+    <TokenGrid title="Pesos" tokens={tokens.typography.fontWeight} />
+  </div>
+);
+
+export const SpacingTokenGrid: React.FC<{ tokens?: DesignTokens }> = ({ tokens = lightTokens }) => (
+  <TokenGrid
+    title="Escala de espaçamento"
+    tokens={tokens.spacing}
+    renderPreview={(value) => (
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--ds-spacing-2)'
+        }}
+      >
+        <span
+          style={{
+            display: 'inline-block',
+            height: '16px',
+            width: String(value),
+            minWidth: '8px',
+            backgroundColor: 'var(--ds-colors-primary-200)',
+            borderRadius: 'var(--ds-radius-full)'
+          }}
+        />
+        <span>{String(value)}</span>
+      </div>
+    )}
+  />
+);


### PR DESCRIPTION
## Summary
- configure Storybook for the project and expose light/dark token sets inspired by Tailwind
- implement a design-system package with theming utilities, shared styles and primitives
- add button, text input, data table and bar chart components with MDX documentation covering key states

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68ce0536a50883268e185fd450990979