### PR TITLE
Add visualization wrappers for charts and maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "@reduxjs/toolkit": "^2.2.7",
     "@tanstack/react-query": "^5.59.16",
     "axios": "^1.7.7",
+    "echarts": "^5.5.1",
+    "mapbox-gl": "^3.6.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-redux": "^9.1.2",

--- a/src/types/external.d.ts
+++ b/src/types/external.d.ts
@@ -1,0 +1,15 @@
+declare module 'echarts' {
+  const echarts: unknown;
+  export default echarts;
+}
+
+declare module 'mapbox-gl' {
+  const mapbox: unknown;
+  export default mapbox;
+}
+
+declare module '@storybook/react' {
+  const storybook: unknown;
+  export default storybook;
+}
+

--- a/src/visualizations/EChartsVisualization.stories.tsx
+++ b/src/visualizations/EChartsVisualization.stories.tsx
@@ -1,0 +1,90 @@
+import type { ComponentType, ReactElement } from 'react';
+import { EChartsVisualization } from './EChartsVisualization';
+import type { EChartsVisualizationProps } from './EChartsVisualization';
+import { DesignSystemProvider } from '../design-system/theme';
+
+type StoryDecorator = (StoryComponent: () => ReactElement) => ReactElement;
+
+type StoryDefinition<TProps> = {
+  args: Partial<TProps>;
+};
+
+type MetaDefinition<TProps> = {
+  title: string;
+  component: ComponentType<TProps>;
+  decorators?: StoryDecorator[];
+  parameters?: Record<string, unknown>;
+};
+
+const meta: MetaDefinition<EChartsVisualizationProps> = {
+  title: 'Visualizations/Comparative Dashboard',
+  component: EChartsVisualization,
+  decorators: [
+    (Story: () => ReactElement): ReactElement => (
+      <DesignSystemProvider>
+        <div style={{ padding: 'var(--ds-spacing-6)' }}>
+          <Story />
+        </div>
+      </DesignSystemProvider>
+    )
+  ],
+  parameters: {
+    layout: 'fullscreen'
+  }
+};
+
+export default meta;
+
+type Story = StoryDefinition<EChartsVisualizationProps>;
+
+const quarterlyData = {
+  categories: ['Q1', 'Q2', 'Q3', 'Q4'],
+  series: [
+    {
+      name: 'Captação',
+      type: 'bar' as const,
+      values: [320, 280, 410, 368]
+    },
+    {
+      name: 'Vendas',
+      type: 'line' as const,
+      values: [280, 340, 388, 420],
+      area: true
+    },
+    {
+      name: 'Meta',
+      type: 'line' as const,
+      values: [300, 300, 400, 400]
+    }
+  ]
+};
+
+export const ComparativeOverview: Story = {
+  args: {
+    title: 'Performance comercial por trimestre',
+    description: 'Comparativo entre captação, vendas e metas definidas para 2024.',
+    data: quarterlyData,
+    height: 360,
+    colorScheme: 'primary',
+    valueFormatter: (value: number) => Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value * 1000)
+  }
+};
+
+export const LoadingState: Story = {
+  args: {
+    title: 'Evolução de receita',
+    description: 'Atualizando informações com base nos filtros selecionados.',
+    data: { categories: [], series: [] },
+    isLoading: true
+  }
+};
+
+export const EmptyState: Story = {
+  args: {
+    title: 'Margem por região',
+    description: 'Nenhum resultado encontrado para o período escolhido.',
+    data: { categories: [], series: [] },
+    emptyMessage: 'Ajuste filtros e tente novamente.'
+  }
+};
+

--- a/src/visualizations/EChartsVisualization.tsx
+++ b/src/visualizations/EChartsVisualization.tsx
@@ -1,0 +1,299 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+import { VisualizationContainer } from './VisualizationContainer';
+import type { VisualizationBaseProps } from './VisualizationContainer';
+import { ensureColorPalette, getSchemePalette, type VisualizationColorScheme } from './color-utils';
+import { useDesignSystem } from '../design-system/theme';
+
+type EChartsInstance = {
+  setOption: (option: Record<string, unknown>, notMerge?: boolean) => void;
+  dispose: () => void;
+  resize: () => void;
+};
+
+type EChartsModule = {
+  init: (
+    element: HTMLDivElement,
+    theme?: unknown,
+    options?: { renderer?: 'canvas' | 'svg' }
+  ) => EChartsInstance;
+  default?: EChartsModule;
+};
+
+type ChartSeriesType = 'bar' | 'line';
+
+export type ComparativeSeries = {
+  name: string;
+  type?: ChartSeriesType;
+  values: Array<number | null>;
+  stack?: string;
+  area?: boolean;
+};
+
+export type ComparativeChartData = {
+  categories: string[];
+  series: ComparativeSeries[];
+};
+
+export type EChartsVisualizationProps = VisualizationBaseProps & {
+  data: ComparativeChartData;
+  valueFormatter?: (value: number) => string;
+  colorScheme?: VisualizationColorScheme;
+  colors?: string[];
+  optionOverrides?: Record<string, unknown>;
+  onChartReady?: (instance: EChartsInstance) => void;
+};
+
+const defaultFormatter = (value: number) =>
+  Intl.NumberFormat('pt-BR', { maximumFractionDigits: 1 }).format(value);
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const mergeDeep = <T extends Record<string, unknown>>(
+  target: T,
+  source?: Record<string, unknown>
+): T => {
+  if (!source) {
+    return target;
+  }
+
+  const output: Record<string, unknown> = { ...target };
+
+  Object.entries(source).forEach(([key, value]) => {
+    if (value === undefined) {
+      return;
+    }
+
+    if (isPlainObject(value) && isPlainObject(output[key] as unknown)) {
+      output[key] = mergeDeep(output[key] as Record<string, unknown>, value);
+      return;
+    }
+
+    output[key] = value;
+  });
+
+  return output as T;
+};
+
+const hasSeriesData = (series: ComparativeSeries[]): boolean =>
+  series.some((serie) => serie.values.some((value) => value !== null && value !== undefined));
+
+export const EChartsVisualization: React.FC<EChartsVisualizationProps> = ({
+  title,
+  description,
+  actions,
+  data,
+  valueFormatter = defaultFormatter,
+  colorScheme = 'primary',
+  colors,
+  optionOverrides,
+  onChartReady,
+  isLoading,
+  error,
+  emptyMessage = 'Inclua filtros ou ajuste o período para visualizar os resultados.',
+  height = 360,
+  className,
+  style
+}) => {
+  const { tokens } = useDesignSystem();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const chartRef = useRef<EChartsInstance | null>(null);
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
+  const [loadError, setLoadError] = useState<ReactNode | null>(null);
+
+  const palette = useMemo(() => {
+    const fallback = getSchemePalette(tokens, colorScheme, tokens.colors.text);
+    return ensureColorPalette(colors, fallback);
+  }, [tokens, colorScheme, colors]);
+
+  useEffect(() => {
+    if (!containerRef.current || typeof window === 'undefined') {
+      return;
+    }
+
+    let isMounted = true;
+
+    const setup = async () => {
+      try {
+        const module = (await import(/* @vite-ignore */ 'echarts')) as EChartsModule;
+        const echarts = module.default ?? module;
+
+        if (!isMounted || !containerRef.current) {
+          return;
+        }
+
+        const instance = echarts.init(containerRef.current, undefined, { renderer: 'canvas' });
+        chartRef.current = instance;
+        onChartReady?.(instance);
+
+        const resizeObserver = new ResizeObserver(() => {
+          instance.resize();
+        });
+        resizeObserver.observe(containerRef.current);
+        resizeObserverRef.current = resizeObserver;
+        setLoadError(null);
+      } catch (err) {
+        console.error('ECharts not available', err);
+        if (isMounted) {
+          setLoadError('Não foi possível carregar a biblioteca de gráficos.');
+        }
+      }
+    };
+
+    setup();
+
+    return () => {
+      isMounted = false;
+      resizeObserverRef.current?.disconnect();
+      resizeObserverRef.current = null;
+      chartRef.current?.dispose();
+      chartRef.current = null;
+    };
+  }, [onChartReady]);
+
+  useEffect(() => {
+    const chart = chartRef.current;
+    if (!chart || !hasSeriesData(data.series)) {
+      return;
+    }
+
+    const categoryLabels = data.categories;
+
+    const axisTextColor = tokens.colors.textMuted;
+    const gridColor = tokens.colors.surfaceMuted;
+
+    const baseOption: Record<string, unknown> = {
+      color: palette,
+      backgroundColor: 'transparent',
+      textStyle: {
+        color: tokens.colors.text,
+        fontFamily: tokens.typography.fontFamily.sans
+      },
+      tooltip: {
+        trigger: 'axis',
+        axisPointer: { type: 'shadow' },
+        backgroundColor: tokens.colors.surface,
+        borderColor: tokens.colors.border,
+        textStyle: {
+          color: tokens.colors.text,
+          fontSize: tokens.typography.fontSize.sm
+        },
+        valueFormatter: (value: number) => valueFormatter(Number(value))
+      },
+      legend: {
+        top: 0,
+        textStyle: {
+          color: axisTextColor,
+          fontSize: tokens.typography.fontSize.sm
+        },
+        itemHeight: 10
+      },
+      grid: {
+        top: 56,
+        left: 56,
+        right: 32,
+        bottom: 40
+      },
+      xAxis: {
+        type: 'category',
+        data: categoryLabels,
+        axisLine: {
+          lineStyle: { color: tokens.colors.border }
+        },
+        axisTick: { show: false },
+        axisLabel: {
+          color: axisTextColor,
+          fontSize: tokens.typography.fontSize.sm
+        }
+      },
+      yAxis: {
+        type: 'value',
+        axisLine: { show: false },
+        axisTick: { show: false },
+        splitLine: {
+          show: true,
+          lineStyle: { color: gridColor }
+        },
+        axisLabel: {
+          color: axisTextColor,
+          fontSize: tokens.typography.fontSize.sm,
+          formatter: (value: number) => valueFormatter(Number(value))
+        }
+      },
+      series: data.series.map((serie, index) => {
+        const paletteColor = palette[index % palette.length];
+        const type = serie.type ?? 'bar';
+        return {
+          name: serie.name,
+          type,
+          data: serie.values,
+          stack: serie.stack,
+          smooth: type === 'line',
+          showSymbol: type === 'line',
+          symbol: 'circle',
+          symbolSize: 10,
+          itemStyle: {
+            color: paletteColor
+          },
+          lineStyle: {
+            color: paletteColor,
+            width: 3
+          },
+          areaStyle:
+            type === 'line' && serie.area
+              ? {
+                  color: paletteColor,
+                  opacity: 0.16
+                }
+              : undefined,
+          emphasis: {
+            focus: 'series'
+          }
+        };
+      })
+    };
+
+    const finalOption = mergeDeep(baseOption, optionOverrides);
+
+    chart.setOption(finalOption, true);
+  }, [data, palette, tokens, valueFormatter, optionOverrides]);
+
+  useEffect(() => {
+    const chart = chartRef.current;
+    if (!chart) {
+      return;
+    }
+
+    if (!hasSeriesData(data.series)) {
+      chart.setOption({ series: [] }, true);
+    }
+  }, [data]);
+
+  const combinedError = error ?? loadError;
+  const isEmpty = !hasSeriesData(data.series) || data.categories.length === 0;
+
+  return (
+    <VisualizationContainer
+      title={title}
+      description={description}
+      actions={actions}
+      isLoading={isLoading}
+      error={combinedError}
+      emptyMessage={emptyMessage}
+      isEmpty={isEmpty && !combinedError && !isLoading}
+      height={height}
+      className={className}
+      style={style}
+    >
+      <div
+        ref={containerRef}
+        style={{
+          width: '100%',
+          height: '100%'
+        }}
+      />
+    </VisualizationContainer>
+  );
+};
+

--- a/src/visualizations/PortfolioMap.stories.tsx
+++ b/src/visualizations/PortfolioMap.stories.tsx
@@ -1,0 +1,92 @@
+import type { ComponentType, ReactElement } from 'react';
+import { PortfolioMap } from './PortfolioMap';
+import type { PortfolioMapProps } from './PortfolioMap';
+import { DesignSystemProvider } from '../design-system/theme';
+
+type StoryDecorator = (StoryComponent: () => ReactElement) => ReactElement;
+
+type StoryDefinition<TProps> = {
+  args: Partial<TProps>;
+};
+
+type MetaDefinition<TProps> = {
+  title: string;
+  component: ComponentType<TProps>;
+  decorators?: StoryDecorator[];
+  parameters?: Record<string, unknown>;
+};
+
+const meta: MetaDefinition<PortfolioMapProps> = {
+  title: 'Visualizations/Portfolio Map',
+  component: PortfolioMap,
+  decorators: [
+    (Story: () => ReactElement): ReactElement => (
+      <DesignSystemProvider>
+        <div style={{ padding: 'var(--ds-spacing-6)' }}>
+          <Story />
+        </div>
+      </DesignSystemProvider>
+    )
+  ],
+  parameters: {
+    layout: 'fullscreen'
+  }
+};
+
+export default meta;
+
+type Story = StoryDefinition<PortfolioMapProps>;
+
+const demoMarkers: PortfolioMapProps['markers'] = [
+  {
+    id: 'sp',
+    title: 'São Paulo',
+    subtitle: '16 imóveis em carteira',
+    value: 'Taxa de ocupação 92%',
+    coordinates: [-46.633309, -23.55052]
+  },
+  {
+    id: 'rio',
+    title: 'Rio de Janeiro',
+    subtitle: '11 imóveis',
+    value: 'Cap rate médio de 8,2%',
+    coordinates: [-43.172897, -22.906847]
+  },
+  {
+    id: 'bh',
+    title: 'Belo Horizonte',
+    subtitle: '7 imóveis',
+    value: 'Vacância 5%',
+    coordinates: [-43.93778, -19.92083]
+  }
+];
+
+export const PortfolioOverview: Story = {
+  args: {
+    title: 'Mapa de portfólio imobiliário',
+    description: 'Distribuição geográfica dos ativos e principais indicadores por praça.',
+    accessToken: 'pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpejY4NXVycTA2emYycXBndHRqcmZ3N3gifQ.lX4LPm6vZjuZkJELrI6dgQ',
+    markers: demoMarkers,
+    height: 420,
+    fitBounds: true
+  }
+};
+
+export const LoadingPortfolio: Story = {
+  args: {
+    title: 'Carregando mapa do portfólio',
+    accessToken: 'pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpejY4NXVycTA2emYycXBndHRqcmZ3N3gifQ.lX4LPm6vZjuZkJELrI6dgQ',
+    markers: demoMarkers,
+    isLoading: true
+  }
+};
+
+export const EmptyPortfolio: Story = {
+  args: {
+    title: 'Nenhum ativo encontrado',
+    accessToken: 'pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpejY4NXVycTA2emYycXBndHRqcmZ3N3gifQ.lX4LPm6vZjuZkJELrI6dgQ',
+    markers: [],
+    emptyMessage: 'Aplique filtros diferentes para explorar novas regiões.'
+  }
+};
+

--- a/src/visualizations/PortfolioMap.tsx
+++ b/src/visualizations/PortfolioMap.tsx
@@ -1,0 +1,311 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+import { VisualizationContainer } from './VisualizationContainer';
+import type { VisualizationBaseProps } from './VisualizationContainer';
+import { ensureColorPalette, getSchemePalette, type VisualizationColorScheme } from './color-utils';
+import { useDesignSystem } from '../design-system/theme';
+
+type MapInstance = {
+  addControl: (...args: unknown[]) => void;
+  remove: () => void;
+  once: (event: string, callback: () => void) => void;
+  easeTo: (options: Record<string, unknown>) => void;
+  fitBounds: (bounds: unknown, options: Record<string, unknown>) => void;
+  getZoom: () => number;
+};
+
+type MarkerInstance = {
+  setLngLat: (value: unknown) => MarkerInstance;
+  addTo: (map: MapInstance) => MarkerInstance;
+  setPopup: (popup: PopupInstance) => MarkerInstance;
+  getElement: () => HTMLElement;
+  remove: () => void;
+};
+
+type PopupInstance = {
+  setHTML: (value: string) => PopupInstance;
+};
+
+type MapboxModule = {
+  Map: new (options: Record<string, unknown>) => MapInstance;
+  Marker: new (options: Record<string, unknown>) => MarkerInstance;
+  Popup: new (options: Record<string, unknown>) => PopupInstance;
+  NavigationControl: new (options?: Record<string, unknown>) => unknown;
+  LngLatBounds: new (sw: unknown, ne: unknown) => { extend: (value: unknown) => void };
+  accessToken: string;
+  default?: MapboxModule;
+};
+
+type LngLatLike = unknown;
+type LngLatBoundsLike = unknown;
+
+export type PortfolioMarker = {
+  id: string;
+  coordinates: [number, number];
+  title: string;
+  subtitle?: string;
+  value?: string;
+  color?: string;
+};
+
+export type PortfolioMapProps = VisualizationBaseProps & {
+  accessToken?: string;
+  center?: [number, number];
+  zoom?: number;
+  markers?: PortfolioMarker[];
+  mapStyle?: string;
+  fitBounds?: boolean;
+  colorScheme?: VisualizationColorScheme;
+  colors?: string[];
+  onMarkerClick?: (marker: PortfolioMarker) => void;
+};
+
+type InternalMarker = {
+  marker: MarkerInstance;
+  cleanup?: () => void;
+};
+
+const DEFAULT_CENTER: [number, number] = [-47.8825, -15.7942];
+
+const cssAlreadyLoaded = () =>
+  typeof document !== 'undefined' && Boolean(document.querySelector('link[data-mapbox-gl="true"]'));
+
+const loadMapboxCss = () => {
+  if (typeof document === 'undefined' || cssAlreadyLoaded()) {
+    return;
+  }
+
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = 'https://api.mapbox.com/mapbox-gl-js/v3.6.0/mapbox-gl.css';
+  link.dataset.mapboxGl = 'true';
+  document.head.appendChild(link);
+};
+
+const formatPopupContent = (marker: PortfolioMarker, tokens: ReturnType<typeof useDesignSystem>['tokens']): string => {
+  const { title, subtitle, value } = marker;
+  const subtitleSection = subtitle ? `<div style="color:${tokens.colors.textMuted};font-size:${tokens.typography.fontSize.xs};margin-top:4px;">${subtitle}</div>` : '';
+  const valueSection = value
+    ? `<strong style="display:block;margin-top:6px;font-size:${tokens.typography.fontSize.sm};color:${tokens.colors.text};">${value}</strong>`
+    : '';
+  return `
+    <div style="min-width:180px;font-family:${tokens.typography.fontFamily.sans};color:${tokens.colors.text};">
+      <span style="font-size:${tokens.typography.fontSize.sm};font-weight:${tokens.typography.fontWeight.semibold};">${title}</span>
+      ${subtitleSection}
+      ${valueSection}
+    </div>
+  `;
+};
+
+export const PortfolioMap: React.FC<PortfolioMapProps> = ({
+  title,
+  description,
+  actions,
+  accessToken,
+  center,
+  zoom,
+  markers = [],
+  mapStyle,
+  fitBounds = true,
+  colorScheme = 'primary',
+  colors,
+  onMarkerClick,
+  isLoading,
+  error,
+  emptyMessage = 'Nenhum ativo do portfólio foi localizado para os filtros informados.',
+  height = 420,
+  className,
+  style
+}) => {
+  const designSystem = useDesignSystem();
+  const { tokens, theme } = designSystem;
+  const mapContainerRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<MapInstance | null>(null);
+  const markersRef = useRef<InternalMarker[]>([]);
+  const mapboxModuleRef = useRef<MapboxModule | null>(null);
+  const [mapReady, setMapReady] = useState(false);
+  const [loadError, setLoadError] = useState<ReactNode | null>(null);
+
+  const palette = useMemo(() => {
+    const fallback = getSchemePalette(tokens, colorScheme, tokens.colors.primary?.foreground ?? tokens.colors.text);
+    return ensureColorPalette(colors, fallback);
+  }, [tokens, colorScheme, colors]);
+
+  const resolvedStyle = useMemo(() => {
+    if (mapStyle) {
+      return mapStyle;
+    }
+    return theme === 'dark' ? 'mapbox://styles/mapbox/dark-v11' : 'mapbox://styles/mapbox/light-v11';
+  }, [mapStyle, theme]);
+
+  useEffect(() => {
+    loadMapboxCss();
+  }, []);
+
+  useEffect(() => {
+    if (!mapContainerRef.current || typeof window === 'undefined') {
+      return;
+    }
+
+    if (!accessToken) {
+      setLoadError('Informe um token do Mapbox para visualizar o mapa.');
+      markersRef.current.forEach((item) => {
+        item.cleanup?.();
+        item.marker.remove();
+      });
+      markersRef.current = [];
+      mapRef.current?.remove();
+      mapRef.current = null;
+      mapboxModuleRef.current = null;
+      return;
+    }
+
+    let isMounted = true;
+    setMapReady(false);
+
+    const initialize = async () => {
+      try {
+        const module = (await import(/* @vite-ignore */ 'mapbox-gl')) as MapboxModule;
+        const mapbox = module?.default ?? module;
+
+        if (!isMounted || !mapContainerRef.current) {
+          return;
+        }
+
+        mapbox.accessToken = accessToken;
+        mapboxModuleRef.current = mapbox;
+
+        const instance = new mapbox.Map({
+          container: mapContainerRef.current,
+          style: resolvedStyle,
+          center: (center as LngLatLike) ?? DEFAULT_CENTER,
+          zoom: zoom ?? 3,
+          attributionControl: true
+        });
+
+        instance.addControl(new mapbox.NavigationControl({ visualizePitch: true }), 'top-right');
+
+        mapRef.current = instance;
+        setLoadError(null);
+
+        const handleLoad = () => {
+          setMapReady(true);
+        };
+
+        instance.once('load', handleLoad);
+      } catch (err) {
+        console.error('Mapbox GL not available', err);
+        if (isMounted) {
+          setLoadError('Não foi possível carregar o mapa interativo.');
+        }
+      }
+    };
+
+    initialize();
+
+    return () => {
+      isMounted = false;
+      markersRef.current.forEach((item) => {
+        item.cleanup?.();
+        item.marker.remove();
+      });
+      markersRef.current = [];
+      mapRef.current?.remove();
+      mapRef.current = null;
+      mapboxModuleRef.current = null;
+    };
+  }, [accessToken, center, zoom, resolvedStyle]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    const mapbox = mapboxModuleRef.current;
+    if (!map || !mapReady || !mapbox) {
+      return;
+    }
+
+    markersRef.current.forEach((item) => {
+      item.cleanup?.();
+      item.marker.remove();
+    });
+    markersRef.current = [];
+
+    if (!markers.length) {
+      return;
+    }
+
+    const defaultColor = palette[0] ?? tokens.colors.primary?.[500] ?? '#2563eb';
+
+    const nextMarkers: InternalMarker[] = markers.map((marker) => {
+      const markerColor = marker.color ?? defaultColor;
+      const instance = new mapbox.Marker({ color: markerColor });
+      instance.setLngLat(marker.coordinates as LngLatLike).addTo(map);
+
+      let popup: PopupInstance | undefined;
+      if (marker.subtitle || marker.value) {
+        popup = new mapbox.Popup({ offset: 12 }).setHTML(formatPopupContent(marker, tokens));
+        instance.setPopup(popup);
+      }
+
+      let cleanup: (() => void) | undefined;
+      if (onMarkerClick) {
+        const element = instance.getElement();
+        const handleClick = () => onMarkerClick(marker);
+        element.addEventListener('click', handleClick);
+        cleanup = () => {
+          element.removeEventListener('click', handleClick);
+        };
+      }
+
+      return { marker: instance, cleanup };
+    });
+
+    markersRef.current = nextMarkers;
+
+    if (!fitBounds) {
+      return;
+    }
+
+    if (markers.length === 1) {
+      map.easeTo({ center: markers[0].coordinates as LngLatLike, duration: 600, zoom: Math.max(zoom ?? map.getZoom(), 10) });
+      return;
+    }
+
+    const bounds = new mapbox.LngLatBounds(markers[0].coordinates as LngLatLike, markers[0].coordinates as LngLatLike);
+    markers.slice(1).forEach((marker) => {
+      bounds.extend(marker.coordinates as LngLatLike);
+    });
+    map.fitBounds(bounds as LngLatBoundsLike, { padding: 48, duration: 700, maxZoom: 14 });
+  }, [markers, mapReady, onMarkerClick, palette, fitBounds, tokens, zoom]);
+
+  const combinedError = error ?? loadError;
+  const isEmpty = markers.length === 0;
+  const shouldShowLoading = Boolean(isLoading) || (!combinedError && !isEmpty && !mapReady);
+
+  return (
+    <VisualizationContainer
+      title={title}
+      description={description}
+      actions={actions}
+      isLoading={shouldShowLoading}
+      error={combinedError}
+      emptyMessage={emptyMessage}
+      isEmpty={isEmpty && !combinedError && !shouldShowLoading}
+      height={height}
+      className={className}
+      style={style}
+    >
+      <div
+        ref={mapContainerRef}
+        style={{
+          width: '100%',
+          height: '100%',
+          borderRadius: tokens.radius.md,
+          overflow: 'hidden',
+          boxShadow: tokens.shadow.sm,
+          backgroundColor: tokens.colors.surfaceMuted
+        }}
+      />
+    </VisualizationContainer>
+  );
+};
+

--- a/src/visualizations/VisualizationContainer.tsx
+++ b/src/visualizations/VisualizationContainer.tsx
@@ -1,0 +1,184 @@
+import React from 'react';
+import type { CSSProperties, ReactNode } from 'react';
+import { useDesignSystem } from '../design-system/theme';
+import { Spinner } from '../design-system/components/_shared/Spinner';
+
+export type VisualizationBaseProps = {
+  title?: ReactNode;
+  description?: ReactNode;
+  actions?: ReactNode;
+  isLoading?: boolean;
+  error?: ReactNode;
+  emptyMessage?: ReactNode;
+  height?: number | string;
+  className?: string;
+  style?: CSSProperties;
+};
+
+export type VisualizationContainerProps = VisualizationBaseProps & {
+  children: ReactNode;
+  isEmpty?: boolean;
+};
+
+const resolveHeight = (height?: number | string): string | undefined => {
+  if (typeof height === 'number') {
+    return `${height}px`;
+  }
+
+  return height;
+};
+
+export const VisualizationContainer: React.FC<VisualizationContainerProps> = ({
+  title,
+  description,
+  actions,
+  isLoading = false,
+  error,
+  emptyMessage = 'Sem dados para exibir.',
+  isEmpty = false,
+  height = 320,
+  className,
+  style,
+  children
+}) => {
+  const { tokens } = useDesignSystem();
+  const resolvedHeight = resolveHeight(height) ?? '320px';
+
+  const renderState = () => {
+    if (error) {
+      return (
+        <div
+          role="alert"
+          className="ds-card"
+          style={{
+            padding: tokens.spacing['4'],
+            borderRadius: tokens.radius.md,
+            backgroundColor: tokens.colors.surfaceMuted,
+            border: `1px dashed ${tokens.colors.border}`,
+            textAlign: 'center'
+          }}
+        >
+          <strong style={{ display: 'block', marginBottom: tokens.spacing['2'] }}>Não foi possível carregar os dados.</strong>
+          <span className="ds-text-muted" style={{ fontSize: tokens.typography.fontSize.sm }}>
+            {error}
+          </span>
+        </div>
+      );
+    }
+
+    if (isEmpty) {
+      return (
+        <div
+          style={{
+            padding: tokens.spacing['4'],
+            borderRadius: tokens.radius.md,
+            backgroundColor: tokens.colors.surfaceMuted,
+            border: `1px dashed ${tokens.colors.border}`,
+            textAlign: 'center'
+          }}
+        >
+          <strong style={{ display: 'block', marginBottom: tokens.spacing['2'] }}>Nada por aqui ainda</strong>
+          <span className="ds-text-muted" style={{ fontSize: tokens.typography.fontSize.sm }}>
+            {emptyMessage}
+          </span>
+        </div>
+      );
+    }
+
+    return children;
+  };
+
+  return (
+    <section
+      aria-busy={isLoading}
+      className={className}
+      style={{
+        display: 'grid',
+        gap: tokens.spacing['4'],
+        padding: tokens.spacing['5'],
+        borderRadius: tokens.radius.lg,
+        border: `1px solid ${tokens.colors.border}`,
+        backgroundColor: tokens.colors.surface,
+        boxShadow: tokens.shadow.sm,
+        minWidth: 0,
+        ...(style ?? {})
+      }}
+    >
+      {(title || description || actions) && (
+        <header
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            alignItems: actions ? 'center' : 'flex-start',
+            gap: tokens.spacing['3'],
+            justifyContent: actions ? 'space-between' : 'flex-start'
+          }}
+        >
+          <div style={{ display: 'grid', gap: tokens.spacing['1'], minWidth: 0 }}>
+            {title ? (
+              <h3
+                style={{
+                  margin: 0,
+                  fontSize: tokens.typography.fontSize.lg,
+                  fontWeight: tokens.typography.fontWeight.semibold,
+                  color: tokens.colors.text
+                }}
+              >
+                {title}
+              </h3>
+            ) : null}
+            {description ? (
+              <p
+                style={{
+                  margin: 0,
+                  color: tokens.colors.textMuted,
+                  fontSize: tokens.typography.fontSize.sm
+                }}
+              >
+                {description}
+              </p>
+            ) : null}
+          </div>
+          {actions ? <div style={{ marginLeft: 'auto' }}>{actions}</div> : null}
+        </header>
+      )}
+      <div
+        style={{
+          position: 'relative',
+          minHeight: resolvedHeight,
+          width: '100%'
+        }}
+      >
+        {isLoading ? (
+          <div
+            style={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              background: `color-mix(in srgb, ${tokens.colors.surface} 85%, transparent)`,
+              backdropFilter: 'blur(2px)',
+              zIndex: 2
+            }}
+          >
+            <Spinner />
+          </div>
+        ) : null}
+        <div
+          style={{
+            height: resolvedHeight,
+            width: '100%',
+            position: 'relative',
+            zIndex: 1,
+            opacity: isLoading ? 0.4 : 1,
+            transition: 'opacity 0.3s ease'
+          }}
+        >
+          {renderState()}
+        </div>
+      </div>
+    </section>
+  );
+};
+

--- a/src/visualizations/color-utils.ts
+++ b/src/visualizations/color-utils.ts
@@ -1,0 +1,59 @@
+import type { DesignTokens } from '../design-system/theme';
+
+export type VisualizationColorScheme = 'primary' | 'success' | 'warning' | 'danger';
+
+const COLOR_PRIORITY = ['500', '600', '400', '700', '300', '800', '200', '900', '100'];
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const extractPalette = (tokenValue: unknown): string[] => {
+  if (typeof tokenValue === 'string') {
+    return [tokenValue];
+  }
+
+  if (!isRecord(tokenValue)) {
+    return [];
+  }
+
+  const prioritized = COLOR_PRIORITY.map((key) => tokenValue[key]).filter(
+    (value): value is string => typeof value === 'string'
+  );
+
+  const numericKeys = Object.keys(tokenValue)
+    .filter((key) => /^\d+$/.test(key) && !COLOR_PRIORITY.includes(key))
+    .sort((a, b) => Number(a) - Number(b))
+    .map((key) => tokenValue[key])
+    .filter((value): value is string => typeof value === 'string');
+
+  const merged = [...prioritized, ...numericKeys];
+
+  return Array.from(new Set(merged));
+};
+
+export const getSchemePalette = (
+  tokens: DesignTokens,
+  scheme: VisualizationColorScheme,
+  fallback: string
+): string[] => {
+  const rawValue = (tokens.colors as Record<string, unknown>)[scheme];
+
+  const palette = extractPalette(rawValue);
+
+  if (palette.length > 0) {
+    return palette;
+  }
+
+  return [fallback];
+};
+
+export const ensureColorPalette = (colors: string[] | undefined, fallback: string[]): string[] => {
+  const filtered = (colors ?? []).filter((value): value is string => Boolean(value));
+
+  if (filtered.length > 0) {
+    return filtered;
+  }
+
+  return fallback;
+};
+

--- a/src/visualizations/index.ts
+++ b/src/visualizations/index.ts
@@ -1,0 +1,13 @@
+export { EChartsVisualization } from './EChartsVisualization';
+export type {
+  EChartsVisualizationProps,
+  ComparativeChartData,
+  ComparativeSeries
+} from './EChartsVisualization';
+
+export { PortfolioMap } from './PortfolioMap';
+export type { PortfolioMapProps, PortfolioMarker } from './PortfolioMap';
+
+export type { VisualizationBaseProps } from './VisualizationContainer';
+export type { VisualizationColorScheme } from './color-utils';
+


### PR DESCRIPTION
## Summary
- add ECharts and Mapbox GL dependencies together with a reusable visualization container
- implement comparative ECharts dashboard and portfolio Mapbox components using design system tokens and shared props
- document typical chart and map scenarios with Storybook stories for comparative dashboards and portfolio overviews

## Testing
- npm run lint
- npm run test -- --run
- npm run build *(fails: pre-existing TypeScript errors in pipeline selectors and query hooks)*

------
https://chatgpt.com/codex/tasks/task_b_68ce084cdf0c83268bc2dceacf28f8c4