### PR TITLE
Fix domain wildcard redirects

### DIFF
--- a/src/domains/analise/index.tsx
+++ b/src/domains/analise/index.tsx
@@ -259,7 +259,7 @@ export default function AnalysisDomain() {
         <Route index element={<AnalysisOverview />} />
         <Route path="modelagem" element={<AnalysisValuation />} />
         <Route path="cenarios" element={<AnalysisScenarios />} />
-        <Route path="*" element={<Navigate to="." replace />} />
+        <Route path="*" element={<Navigate to=".." replace />} />
       </Route>
     </Routes>
   );

--- a/src/domains/gestao/index.tsx
+++ b/src/domains/gestao/index.tsx
@@ -227,7 +227,7 @@ export default function PortfolioDomain() {
         <Route index element={<PortfolioOverview />} />
         <Route path="distribuicao" element={<PortfolioDistribution />} />
         <Route path="indicadores" element={<PortfolioIndicators />} />
-        <Route path="*" element={<Navigate to="." replace />} />
+        <Route path="*" element={<Navigate to=".." replace />} />
       </Route>
     </Routes>
   );

--- a/src/domains/originacao/index.tsx
+++ b/src/domains/originacao/index.tsx
@@ -570,7 +570,7 @@ export default function OriginationDomain() {
         <Route index element={<OriginationOverview />} />
         <Route path="pipeline" element={<OriginationPipeline />} />
         <Route path="relatorios" element={<OriginationReports />} />
-        <Route path="*" element={<Navigate to="." replace />} />
+        <Route path="*" element={<Navigate to=".." replace />} />
       </Route>
     </Routes>
   );


### PR DESCRIPTION
## Summary
- redirect unknown origination child paths back to the domain routes by using relative navigation
- apply the same fallback redirection to the analysis and portfolio domains to drop invalid segments

## Testing
- npm run lint
- npm run dev -- --host 0.0.0.0 --port 4173 *(fails: existing build error complaining about "stage || stageOptions[0] ?? 'Lead'")*

------
https://chatgpt.com/codex/tasks/task_b_68ce13435e748326ba85af34ff2d7731