### PR TITLE
feat: criar landing page da Prop-Stream University

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,19 +5,11 @@ import './App.css';
 import AppShell from './app/AppShell';
 import HttpEventsListener from './app/HttpEventsListener';
 import UserPreferencesLoader from './app/UserPreferencesLoader';
+import HomePage from './home/HomePage';
 
 const OriginationDomain = lazy(() => import('./domains/originacao'));
 const AnalysisDomain = lazy(() => import('./domains/analise'));
 const PortfolioDomain = lazy(() => import('./domains/gestao'));
-
-function HomePage() {
-  return (
-    <section className="app">
-      <h1>Prop-Stream</h1>
-      <p>Seu cockpit inteligente para investimentos imobiliários.</p>
-    </section>
-  );
-}
 
 function App() {
   return (

--- a/src/home/HomePage.css
+++ b/src/home/HomePage.css
@@ -1,0 +1,553 @@
+:root {
+  --home-bg: #f5f7fb;
+  --home-surface: #ffffff;
+  --home-surface-muted: #eef3fb;
+  --home-text-primary: #0f172a;
+  --home-text-secondary: #475569;
+  --home-accent: linear-gradient(135deg, #0ea5e9, #22d3ee);
+  --home-border: rgba(148, 163, 184, 0.25);
+  --home-radius-lg: 32px;
+  --home-radius-md: 20px;
+  --home-radius-sm: 14px;
+  --home-shadow-soft: 0 20px 60px rgba(15, 23, 42, 0.12);
+  --home-shadow-muted: 0 16px 40px rgba(15, 23, 42, 0.08);
+}
+
+.home {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 3vw, 3rem);
+  color: var(--home-text-primary);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+.home__hero {
+  background: var(--home-bg);
+  border-radius: var(--home-radius-lg);
+  padding: clamp(1.5rem, 3vw, 3rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 3vw, 3rem);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.home__navbar {
+  display: flex;
+  align-items: center;
+  gap: clamp(1rem, 2vw, 2.5rem);
+  flex-wrap: wrap;
+}
+
+.home__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 700;
+  font-size: 1.2rem;
+}
+
+.home__brand span {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  color: var(--home-text-secondary);
+}
+
+.home__brand-mark {
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(45, 212, 191, 0.25), rgba(14, 165, 233, 0.5));
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.home__brand-mark span {
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 0.6rem;
+  border: 2px solid rgba(255, 255, 255, 0.9);
+  border-bottom-left-radius: 0.1rem;
+  transform: rotate(-12deg);
+  background: rgba(15, 118, 110, 0.25);
+}
+
+.home__nav ul {
+  list-style: none;
+  display: flex;
+  gap: 1.5rem;
+  padding: 0;
+  margin: 0;
+  flex-wrap: wrap;
+}
+
+.home__nav a {
+  color: var(--home-text-secondary);
+  font-weight: 500;
+  text-decoration: none;
+  font-size: 0.95rem;
+}
+
+.home__nav a:hover,
+.home__nav a:focus-visible {
+  color: #0e7490;
+}
+
+.home__navbar-actions {
+  display: inline-flex;
+  gap: 0.75rem;
+  margin-left: auto;
+  align-items: center;
+}
+
+.home__link-muted {
+  color: var(--home-text-secondary);
+  text-decoration: none;
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.home__cta-primary,
+.home__cta-secondary {
+  border-radius: 999px;
+  padding: 0.65rem 1.5rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  border: none;
+  transition: transform 150ms ease, box-shadow 150ms ease, opacity 150ms ease;
+}
+
+.home__cta-primary {
+  background: var(--home-accent);
+  color: #0f172a;
+  box-shadow: 0 16px 30px rgba(14, 165, 233, 0.35);
+}
+
+.home__cta-secondary {
+  background: rgba(14, 165, 233, 0.12);
+  color: #0369a1;
+  border: 1px solid rgba(14, 165, 233, 0.35);
+}
+
+.home__cta-primary:hover,
+.home__cta-secondary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 34px rgba(14, 165, 233, 0.35);
+}
+
+.home__hero-content {
+  display: grid;
+  gap: clamp(2rem, 3vw, 3.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+}
+
+.home__hero-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.home__hero-eyebrow {
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  color: #0e7490;
+  font-weight: 600;
+}
+
+.home__hero h1 {
+  font-size: clamp(2.2rem, 4vw, 3rem);
+  margin: 0;
+}
+
+.home__hero p {
+  margin: 0;
+  color: var(--home-text-secondary);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.home__hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.home__hero-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1rem;
+  margin: 0;
+}
+
+.home__hero-stats dt {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--home-text-secondary);
+}
+
+.home__hero-stats dd {
+  margin: 0.25rem 0 0;
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.home__hero-visual {
+  display: grid;
+  gap: 1rem;
+}
+
+.home__hero-card {
+  background: var(--home-surface);
+  border-radius: var(--home-radius-md);
+  padding: 1.35rem;
+  box-shadow: var(--home-shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  border: 1px solid rgba(226, 232, 240, 0.7);
+}
+
+.home__hero-card-label {
+  font-size: 0.75rem;
+  color: var(--home-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+.home__hero-card-value {
+  font-size: 1.65rem;
+  font-weight: 700;
+  color: #0369a1;
+}
+
+.home__hero-card p {
+  margin: 0;
+  color: var(--home-text-secondary);
+  font-size: 0.95rem;
+}
+
+.home__content {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 3vw, 3rem);
+}
+
+.home__section {
+  background: var(--home-surface);
+  border-radius: var(--home-radius-lg);
+  padding: clamp(1.75rem, 3vw, 3rem);
+  box-shadow: var(--home-shadow-muted);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 2vw, 2.25rem);
+}
+
+.home__section--muted {
+  background: var(--home-surface-muted);
+  box-shadow: none;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.home__section--compact {
+  gap: 1.5rem;
+}
+
+.home__section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.home__section-header > div > h2 {
+  margin: 0;
+  font-size: clamp(1.5rem, 2.5vw, 2.1rem);
+}
+
+.home__section-header > div > p {
+  margin: 0;
+  color: var(--home-text-secondary);
+  line-height: 1.6;
+}
+
+.home__section-eyebrow {
+  display: inline-block;
+  background: rgba(14, 165, 233, 0.12);
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: #0369a1;
+}
+
+.home__category-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.home__category-pills button {
+  border-radius: 999px;
+  padding: 0.45rem 1.1rem;
+  background: #ffffff;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--home-text-secondary);
+  cursor: pointer;
+}
+
+.home__category-pills button:hover,
+.home__category-pills button:focus-visible {
+  border-color: rgba(14, 165, 233, 0.45);
+  color: #0369a1;
+}
+
+.home__catalog-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.home__catalog-card {
+  background: #ffffff;
+  border-radius: var(--home-radius-sm);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+}
+
+.home__catalog-card h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.home__catalog-card p {
+  margin: 0.35rem 0 0;
+  color: var(--home-text-secondary);
+}
+
+.home__catalog-card footer {
+  display: flex;
+  justify-content: space-between;
+  color: #0e7490;
+  font-weight: 600;
+}
+
+.home__featured-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.home__featured-card {
+  background: #ffffff;
+  border-radius: var(--home-radius-sm);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.home__featured-card h3 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.home__featured-card p {
+  margin: 0.35rem 0 0;
+  color: var(--home-text-secondary);
+}
+
+.home__featured-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.home__featured-meta dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--home-text-secondary);
+}
+
+.home__featured-meta dd {
+  margin: 0.25rem 0 0;
+  font-weight: 600;
+}
+
+.home__featured-highlights {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.home__featured-highlights li {
+  padding-left: 1.25rem;
+  position: relative;
+  color: var(--home-text-secondary);
+}
+
+.home__featured-highlights li::before {
+  content: '✔';
+  position: absolute;
+  left: 0;
+  color: #059669;
+}
+
+.home__featured-card button {
+  align-self: flex-start;
+  border-radius: 999px;
+  padding: 0.55rem 1.25rem;
+  border: none;
+  background: rgba(14, 165, 233, 0.12);
+  color: #0369a1;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.home__split {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.home__path-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.home__path-step {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1.25rem;
+  align-items: start;
+  padding: 1.25rem;
+  border-radius: var(--home-radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: #ffffff;
+}
+
+.home__path-index {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #0e7490;
+  letter-spacing: 0.08em;
+}
+
+.home__path-step h4 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.home__path-step p {
+  margin: 0.35rem 0 0;
+  color: var(--home-text-secondary);
+}
+
+.home__instructor-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.home__instructor-card {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem;
+  background: #ffffff;
+  border-radius: var(--home-radius-sm);
+  padding: 1.15rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.home__instructor-avatar {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 1rem;
+  background: rgba(14, 165, 233, 0.12);
+  color: #0369a1;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.home__instructor-role {
+  color: var(--home-text-secondary);
+  font-size: 0.9rem;
+  margin: 0.15rem 0 0.4rem;
+}
+
+.home__testimonial-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.home__testimonial {
+  background: #ffffff;
+  border-radius: var(--home-radius-sm);
+  padding: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.home__testimonial blockquote {
+  margin: 0;
+  color: var(--home-text-secondary);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.home__testimonial figcaption {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.home__testimonial strong {
+  font-size: 1rem;
+}
+
+.home__testimonial span {
+  font-size: 0.9rem;
+  color: var(--home-text-secondary);
+}
+
+@media (max-width: 720px) {
+  .home__navbar-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .home__navbar {
+    align-items: flex-start;
+  }
+
+  .home__nav ul {
+    gap: 1rem;
+  }
+}

--- a/src/home/HomePage.tsx
+++ b/src/home/HomePage.tsx
@@ -1,0 +1,438 @@
+import './HomePage.css';
+
+const NAV_LINKS = [
+  { label: 'Home', href: '#inicio' },
+  { label: 'Features', href: '#recursos' },
+  { label: 'Pricing', href: '#planos' },
+  { label: 'Course Catalog', href: '#catalogo' },
+];
+
+const HERO_STATS = [
+  { label: 'Alunos ativos', value: '12k+' },
+  { label: 'Taxa de conclusão', value: '94%' },
+  { label: 'Horas de conteúdo', value: '180h' },
+];
+
+const COURSE_CATEGORIES = [
+  'Fundamentos',
+  'Marketing & Leads',
+  'Análise de Deals',
+  'Financiamento',
+  'Sistemas & Automação',
+];
+
+const CATALOG_COURSES = [
+  {
+    id: 'catalog-intro',
+    title: 'Wholesaling 101',
+    description:
+      'Domine a base do wholesaling com frameworks replicáveis e checklists práticos.',
+    level: 'Iniciante',
+    duration: '8 módulos',
+  },
+  {
+    id: 'catalog-leads',
+    title: 'Máquina de Leads',
+    description:
+      'Crie campanhas multicanal, automatize follow-ups e multiplique suas oportunidades.',
+    level: 'Intermediário',
+    duration: '12 módulos',
+  },
+  {
+    id: 'catalog-analysis',
+    title: 'Deal Analysis Lab',
+    description:
+      'Aprenda a avaliar riscos, precificar contratos e negociar com margem segura.',
+    level: 'Avançado',
+    duration: '10 módulos',
+  },
+];
+
+const FEATURED_COURSES = [
+  {
+    id: 'featured-finding-deals',
+    title: 'Finding Motivated Sellers',
+    summary: 'Treinamento intensivo focado em prospecção em mercados competitivos.',
+    format: 'Sprint de 3 semanas',
+    instructor: 'Marcus Reed',
+    highlights: ['Playbooks de campanhas', 'Scripts prontos', 'Templates de CRM'],
+  },
+  {
+    id: 'featured-analysis',
+    title: 'Deal Analysis & BRRRR Strategy',
+    summary: 'Aprenda a projetar fluxo de caixa, equity pós-reforma e ciclos de refinanciamento.',
+    format: 'Bootcamp ao vivo',
+    instructor: 'Fernanda Lopes',
+    highlights: ['Planilhas dinâmicas', 'Casos reais', 'Suporte de mentoria'],
+  },
+  {
+    id: 'featured-financing',
+    title: 'Creative Financing Toolkit',
+    summary: 'Domine seller financing, novações e estruturas híbridas para fechar mais contratos.',
+    format: 'Programa on-demand',
+    instructor: 'Rafael Martins',
+    highlights: ['Modelos de contratos', 'Bancos de parceiros', 'Checklists jurídicos'],
+  },
+];
+
+const LEARNING_PATH = [
+  {
+    id: 'path-foundations',
+    title: 'Fundamentos de Wholesaling',
+    description: 'Alinhe mentalidade, metas e métricas que importam no jogo de aquisições.',
+  },
+  {
+    id: 'path-prospecting',
+    title: 'Geração de Leads & Marketing',
+    description: 'Construa funis previsíveis com campanhas omnichannel e nurturing contínuo.',
+  },
+  {
+    id: 'path-analysis',
+    title: 'Análise & Negociação',
+    description: 'Faça underwriting completo, desenvolva ofertas irrecusáveis e gerencie objeções.',
+  },
+  {
+    id: 'path-scale',
+    title: 'Escala & Automação',
+    description: 'Implemente sistemas operacionais, contrate o time certo e mantenha margem.',
+  },
+];
+
+const INSTRUCTORS = [
+  {
+    id: 'instructor-marcus',
+    name: 'Marcus Reed',
+    role: 'Head de Aquisições na BlueDoor Capital',
+    focus: 'Especialista em prospecção outbound e parcerias estratégicas.',
+  },
+  {
+    id: 'instructor-fernanda',
+    name: 'Fernanda Lopes',
+    role: 'Analista-Chefe na Prop-Stream',
+    focus: 'Lidera squads de underwriting e valuation de portfólios residenciais.',
+  },
+  {
+    id: 'instructor-rafael',
+    name: 'Rafael Martins',
+    role: 'Consultor Jurídico & Estruturador Financeiro',
+    focus: 'Referência em creative financing e conformidade regulatória.',
+  },
+];
+
+const TESTIMONIALS = [
+  {
+    id: 'testimonial-john',
+    name: 'John Batista',
+    role: 'Founder, Skyline Investimentos',
+    quote:
+      'O playbook de captação e os templates de automação reduziram o ciclo de fechamento em 37%.',
+  },
+  {
+    id: 'testimonial-isabela',
+    name: 'Isabela Freitas',
+    role: 'CEO, Vector Properties',
+    quote:
+      'As mentorias ao vivo transformaram nossa operação em um pipeline previsível e escalável.',
+  },
+];
+
+function HeroVisualCard({
+  title,
+  value,
+  description,
+}: {
+  title: string;
+  value: string;
+  description: string;
+}) {
+  return (
+    <div className="home__hero-card">
+      <span className="home__hero-card-label">{title}</span>
+      <strong className="home__hero-card-value">{value}</strong>
+      <p>{description}</p>
+    </div>
+  );
+}
+
+function CatalogCard({
+  title,
+  description,
+  level,
+  duration,
+}: (typeof CATALOG_COURSES)[number]) {
+  return (
+    <article className="home__catalog-card">
+      <header>
+        <h3>{title}</h3>
+        <p>{description}</p>
+      </header>
+      <footer>
+        <span>{level}</span>
+        <span>{duration}</span>
+      </footer>
+    </article>
+  );
+}
+
+function FeaturedCourseCard({
+  title,
+  summary,
+  format,
+  instructor,
+  highlights,
+}: (typeof FEATURED_COURSES)[number]) {
+  return (
+    <article className="home__featured-card">
+      <header>
+        <h3>{title}</h3>
+        <p>{summary}</p>
+      </header>
+      <dl className="home__featured-meta">
+        <div>
+          <dt>Formato</dt>
+          <dd>{format}</dd>
+        </div>
+        <div>
+          <dt>Instrutor</dt>
+          <dd>{instructor}</dd>
+        </div>
+      </dl>
+      <ul className="home__featured-highlights">
+        {highlights.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+      <button type="button">Ver detalhes</button>
+    </article>
+  );
+}
+
+function LearningPathStep({
+  index,
+  title,
+  description,
+}: (typeof LEARNING_PATH)[number] & { index: number }) {
+  return (
+    <li className="home__path-step">
+      <span className="home__path-index">{index.toString().padStart(2, '0')}</span>
+      <div>
+        <h4>{title}</h4>
+        <p>{description}</p>
+      </div>
+    </li>
+  );
+}
+
+function InstructorCard({ name, role, focus }: (typeof INSTRUCTORS)[number]) {
+  return (
+    <article className="home__instructor-card">
+      <div className="home__instructor-avatar" aria-hidden="true">
+        {name
+          .split(' ')
+          .map((part) => part[0])
+          .join('')}
+      </div>
+      <div>
+        <h4>{name}</h4>
+        <p className="home__instructor-role">{role}</p>
+        <p>{focus}</p>
+      </div>
+    </article>
+  );
+}
+
+function TestimonialCard({ quote, name, role }: (typeof TESTIMONIALS)[number]) {
+  return (
+    <figure className="home__testimonial">
+      <blockquote>
+        <p>“{quote}”</p>
+      </blockquote>
+      <figcaption>
+        <strong>{name}</strong>
+        <span>{role}</span>
+      </figcaption>
+    </figure>
+  );
+}
+
+export default function HomePage() {
+  return (
+    <div className="home" id="inicio">
+      <header className="home__hero">
+        <div className="home__navbar">
+          <div className="home__brand">
+            <span className="home__brand-mark" aria-hidden="true">
+              <span />
+            </span>
+            <div>
+              <strong>Prop-Stream</strong>
+              <span>University</span>
+            </div>
+          </div>
+          <nav aria-label="Navegação principal" className="home__nav" id="recursos">
+            <ul>
+              {NAV_LINKS.map((link) => (
+                <li key={link.href}>
+                  <a href={link.href}>{link.label}</a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+          <div className="home__navbar-actions">
+            <a href="#login" className="home__link-muted">
+              Login
+            </a>
+            <button type="button" className="home__cta-primary">
+              Get Started
+            </button>
+          </div>
+        </div>
+
+        <div className="home__hero-content">
+          <div className="home__hero-copy">
+            <span className="home__hero-eyebrow">Prop-Stream University</span>
+            <h1>Master Real Estate Wholesaling</h1>
+            <p>
+              Destrave seu potencial com trilhas de aprendizado completas, simuladores de deals
+              e mentorias com especialistas para acelerar resultados financeiros reais.
+            </p>
+            <div className="home__hero-actions">
+              <button type="button" className="home__cta-primary">
+                Explorar cursos
+              </button>
+              <button type="button" className="home__cta-secondary">
+                Ver trilha completa
+              </button>
+            </div>
+            <dl className="home__hero-stats">
+              {HERO_STATS.map((stat) => (
+                <div key={stat.label}>
+                  <dt>{stat.label}</dt>
+                  <dd>{stat.value}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+
+          <div className="home__hero-visual" aria-hidden="true">
+            <HeroVisualCard
+              title="Taxa média de fechamento"
+              value="28%"
+              description="+12 pts vs benchmark do mercado após 90 dias de programa."
+            />
+            <HeroVisualCard
+              title="Pipeline ativo"
+              value="36 deals"
+              description="Dashboard integrado com indicadores de prioridade e ROI projetado."
+            />
+            <HeroVisualCard
+              title="Score dos alunos"
+              value="4.9/5"
+              description="Experiência avaliada por mais de 2.400 investidores e operadores."
+            />
+          </div>
+        </div>
+      </header>
+
+      <main className="home__content">
+        <section className="home__section" id="catalogo">
+          <header className="home__section-header">
+            <div>
+              <span className="home__section-eyebrow">Course Catalog</span>
+              <h2>Trilhas construídas para dominar cada etapa do wholesaling</h2>
+              <p>
+                Combine teoria aplicável, estudos de caso e playbooks acionáveis para avançar do
+                primeiro deal à escala com segurança.
+              </p>
+            </div>
+            <div className="home__category-pills">
+              {COURSE_CATEGORIES.map((category) => (
+                <button key={category} type="button">
+                  {category}
+                </button>
+              ))}
+            </div>
+          </header>
+          <div className="home__catalog-grid">
+            {CATALOG_COURSES.map((course) => (
+              <CatalogCard key={course.id} {...course} />
+            ))}
+          </div>
+        </section>
+
+        <section className="home__section home__section--muted" id="destaques">
+          <header className="home__section-header">
+            <div>
+              <span className="home__section-eyebrow">Featured Courses</span>
+              <h2>Programas intensivos com impacto comprovado</h2>
+              <p>
+                Planos de estudo guiados, acompanhamento por mentores e frameworks aplicáveis no dia a dia.
+              </p>
+            </div>
+            <a href="#todos-os-cursos" className="home__link-muted">
+              Ver todos os cursos
+            </a>
+          </header>
+          <div className="home__featured-grid">
+            {FEATURED_COURSES.map((course) => (
+              <FeaturedCourseCard key={course.id} {...course} />
+            ))}
+          </div>
+        </section>
+
+        <div className="home__split">
+          <section className="home__section" id="trilha">
+            <header className="home__section-header">
+              <div>
+                <span className="home__section-eyebrow">Learning Path</span>
+                <h2>Uma jornada estruturada para sair da teoria e fechar deals reais</h2>
+                <p>
+                  Cada etapa libera checklists, simuladores e sessões com especialistas para acelerar sua execução.
+                </p>
+              </div>
+            </header>
+            <ol className="home__path-list">
+              {LEARNING_PATH.map((step, index) => (
+                <LearningPathStep key={step.id} index={index + 1} {...step} />
+              ))}
+            </ol>
+          </section>
+
+          <section className="home__section home__section--compact" id="mentores">
+            <header className="home__section-header">
+              <div>
+                <span className="home__section-eyebrow">Instructor Profiles</span>
+                <h2>Mentores que operam no campo de batalha imobiliário</h2>
+                <p>
+                  Aprenda com executivos, analistas e consultores que lideram operações multimilionárias todos os dias.
+                </p>
+              </div>
+            </header>
+            <div className="home__instructor-grid">
+              {INSTRUCTORS.map((instructor) => (
+                <InstructorCard key={instructor.id} {...instructor} />
+              ))}
+            </div>
+          </section>
+        </div>
+
+        <section className="home__section home__section--muted" id="planos">
+          <header className="home__section-header">
+            <div>
+              <span className="home__section-eyebrow">Testimonials</span>
+              <h2>Resultados que ecoam nos principais mercados</h2>
+              <p>
+                Times que aplicaram a metodologia Prop-Stream University expandiram operações e aumentaram margens em tempo recorde.
+              </p>
+            </div>
+          </header>
+          <div className="home__testimonial-grid">
+            {TESTIMONIALS.map((testimonial) => (
+              <TestimonialCard key={testimonial.id} {...testimonial} />
+            ))}
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implementa homepage completa inspirada no layout da Prop-Stream University com seções de catálogo, cursos em destaque, trilha e depoimentos
- adiciona estilos dedicados para a landing page, incluindo hero, cartões e grades responsivas
- integra a nova homepage ao roteamento principal do aplicativo

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d5a82baa00832686f298ef9e213da8